### PR TITLE
Wrong rendering cell for an action.

### DIFF
--- a/Grid/Column/Action.php
+++ b/Grid/Column/Action.php
@@ -28,6 +28,6 @@ class Action extends Column
 
     public function renderCell($value, $row, $router)
     {
-        return '<input type="checkbox" class="action" value="1" name="'.$this->gridHash.'[__action]['.$row->getPrimaryField().']"/>';
+        return '<input type="checkbox" class="action" value="1" name="'.$this->gridHash.'[__action]['.$row->getPrimaryFieldValue().']"/>';
     }
 }


### PR DESCRIPTION
Without this change, we don't have the selected IDs in the action's callback function.
