### PR TITLE
Inline Filters

### DIFF
--- a/Resources/views/blocks.html.twig
+++ b/Resources/views/blocks.html.twig
@@ -38,6 +38,7 @@
         {% else %}
             {{ column.title }}
         {% endif %}
+        {% if column.filterable is sameas('inline') %}{{ grid_filter(column, grid)|raw }}{% endif %}
         </th>
         {% endif %}
     {% endfor %}
@@ -48,7 +49,7 @@
     <tr>
     {% for column in grid.columns %}
         {% if (column.visible)%}
-        <th>{% if column.filterable %}{{ grid_filter(column, grid)|raw }}{% endif %}</th>
+        {% if column.filterable is sameas(true) %}<th>{{ grid_filter(column, grid)|raw }}</th>{% endif %}
         {% endif %}
     {% endfor %}
     </tr>


### PR DESCRIPTION
Quick proposal.  Often I would like the filters to appear "inline" next to the title.

It would probably also make sense to move MassAction filters up into the title when there are no other non-inline filters, but I'm not quite sure where to make that happen.
