### PR TITLE
Fixed a bug when ordering joined fields.

### DIFF
--- a/Grid/Source/Entity.php
+++ b/Grid/Source/Entity.php
@@ -84,6 +84,7 @@ class Entity extends Source
     
     /**
      * @param \Sorien\DataGridBundle\Grid\Column\Column $column
+     * @param boolean $withAlias
      * @return string
      */
     private function getFieldName($column, $withAlias = true)


### PR DESCRIPTION
Added optional argument to Grid\Source\Entity#getFieldName which determines wheter or not to add an alias to a joined field (default is true).
