### PR TITLE
Minor change to allow customizing cell rendering based on the type of ce...

### DIFF
--- a/Twig/DataGridExtension.php
+++ b/Twig/DataGridExtension.php
@@ -139,6 +139,11 @@ class DataGridExtension extends \Twig_Extension
             return $this->renderBlock($block, array('column' => $column, 'value' => $value, 'row' => $row));
         }
 
+	if ($this->hasBlock($block = 'grid_column_'.$column->getType().'_cell'))
+	{
+	    return $this->renderBlock($block, array('column' => $column, 'value' => $value, 'row' => $row));
+	}
+	
         return $value;
     }
 


### PR DESCRIPTION
...ll. So one can do a grid_column_boolean_cell and have all the boolean cells rendered in the same way without having to resort to multiple different blocks for the same type of cell. Way it is now I'd have to have the following blocks grid_column_active_cell, grid_column_allowed_cell, grid_column_enabled_cell etc etc..
