### PR TITLE
Preventing SQL Subselect for count

### DIFF
--- a/Grid/Source/Entity.php
+++ b/Grid/Source/Entity.php
@@ -246,21 +246,10 @@ class Entity extends Source
 
     public function getTotalCount($columns)
     {
-        $this->query->select($this->getFieldName($columns->getPrimaryColumn()));
         $this->query->setFirstResult(null);
         $this->query->setMaxResults(null);
-
-        $qb = $this->manager->createQueryBuilder();
-
-        $qb->select($qb->expr()->count(self::COUNT_ALIAS. '.' . $columns->getPrimaryColumn()->getField()));
-        $qb->from($this->entityName, self::COUNT_ALIAS);
-        $qb->where($qb->expr()->in(self::COUNT_ALIAS. '.' . $columns->getPrimaryColumn()->getField(), $this->query->getDQL()));
-
-        //copy existing parameters.
-        $qb->setParameters($this->query->getParameters());
-
-        $result = $qb->getQuery()->getSingleResult();
-
+        $this->query->resetDQLPart('orderBy')->select($this->query->expr()->count(self::TABLE_ALIAS.'.'.$columns->getPrimaryColumn()->getField()));
+        $result = $this->query->getQuery()->getSingleResult();
         return (int) $result[1];
     }
 


### PR DESCRIPTION
I noticed that an SQL subselect is used to get the total number of rows. You might run into performance issues with bigger datasets. I just replaced some parts from the original DQL query to get the total count avoiding the subselect.
