### PR TITLE
Move back to 1st page

### DIFF
--- a/Grid/Grid.php
+++ b/Grid/Grid.php
@@ -375,6 +375,11 @@ class Grid
             throw new \Exception('Source have to return Rows object.');
         }
 
+        if (count($this->rows) == 0 && $this->page > 0){
+            $this->page = 0;
+            $this->prepare();
+        }
+
         //add row actions column
         if (count($this->rowActions) > 0)
         {


### PR DESCRIPTION
Suppose you have 300 rows displayed 20 by 20. If you are on the 3rd page and you add filters, you will stay on this page.

If you get less than 40 rows you will have an empty grid. 

I think it's better to move to the 1st page for seeing the results
