### PR TITLE
Two or more levels mapped fields

### DIFF
--- a/Grid/Source/Entity.php
+++ b/Grid/Source/Entity.php
@@ -128,6 +128,8 @@ class Entity extends Source
                 $this->joins['_' . $element] = $parent . '.' . $element;
                 $previousParent = $parent;
                 $parent = '_' . $element;
+            } else {
+                $name .= '.'.$element;
             }
         }
 


### PR DESCRIPTION
I have a grid with an Entity source.
One field is a three level mapped field : department.company.label.

There was an error in the build query. I think these 4 lines fix this issue.

Can you check if it's ok with the Agregate dql functions ?
