### PR TITLE
Improve ajax loading

### DIFF
--- a/Resources/views/blocks_js.jquery.html.twig
+++ b/Resources/views/blocks_js.jquery.html.twig
@@ -9,9 +9,23 @@ function {{ grid.hash }}_goto(url, data, type)
     $.ajax({
         url: url,
         data: data,
-        type: type
-    }).done(function( msg ) {
-        $('#{{ grid.hash }}').parent().replaceWith(msg);
+        type: type,
+        dataType: 'html',
+        dataFilter: function (data, type){
+        
+            grid_temp = document.createElement("div");
+            grid_temp.id = "grid_temp";
+            grid_temp.innerHTML = data;
+            document.body.appendChild(grid_temp);
+            data = $("#grid_temp");
+            $("#grid_temp").remove();
+            
+            return data;
+        }
+    }).done(function( data ) {
+        theForm = data.find('form[id^=grid]');
+        $('#{{ grid.hash }}').replaceWith(theForm);
+        
     });
 
     return false


### PR DESCRIPTION
... AJAX, the request was receiving all the view (not only the grid)

In my case I was receiving 

<div>
  <h1>
  <h2>
  <div class="grid"></div>
  <p></p>
</div>


the replace was changing only the div class="grid" instead of all my view.

result :

<div>
  <h1>
  <h2>
  <div class="grid">
    <div>
      <h1>
      <h2>
      <div class="grid"></div>
      <p></p>
    </div>
  </div>
  <p></p>
</div>


I created a patch for replacing only the form
