### PR TITLE
Fixed Source class executeFromData

### DIFF
--- a/Grid/Source/Source.php
+++ b/Grid/Source/Source.php
@@ -144,6 +144,7 @@ abstract class Source implements DriverInterface
     public function setData($data)
     {
         $this->data = $data;
+        
         return $this;
     }
 
@@ -415,9 +416,6 @@ abstract class Source implements DriverInterface
                     }
                 }
 
-                if( $fieldName === 'remainingCommitment') { 
-                    //echo 'blah';
-                }
                 $row->setField($fieldName, $fieldValue);
             }
 
@@ -495,7 +493,7 @@ abstract class Source implements DriverInterface
                     if ($column->getType() == 'array') {
                         natcasesort($values);
                     }
-                    print_r($values);
+
                     $column->setValues(array_unique($values));
                 }
             }


### PR DESCRIPTION
- Fixed issue caused by filtering over data instead of query. Previously the "break 2" statement caused the code to break out of the $columns foreach loop, meaning that any fields after the _first_ filter field would not be included in the data grid listing.
