### PR TITLE
Fix file Content-Length calculation for export.

### DIFF
--- a/Grid/Export/Export.php
+++ b/Grid/Export/Export.php
@@ -100,7 +100,7 @@ abstract class Export implements ExportInterface, ContainerAwareInterface
         // Response
         if (function_exists('mb_strlen')) {
             $this->content = mb_convert_encoding($this->content, $this->charset, $this->container->getParameter('kernel.charset'));
-            $filesize = mb_strlen($this->content, $this->charset);
+            $filesize = mb_strlen($this->content, '8bit');
         } else {
             $filesize = strlen($this->content);
             $this->charset = $this->container->getParameter('kernel.charset');


### PR DESCRIPTION
Send count of bytes, instead of count of symbols in the Content-Length header.
