### PR TITLE
Allow access to twig global variables in template blocks

### DIFF
--- a/Twig/DataGridExtension.php
+++ b/Twig/DataGridExtension.php
@@ -285,7 +285,7 @@ class DataGridExtension extends \Twig_Extension
     {
         foreach ($this->getTemplates() as $template) {
             if ($template->hasBlock($name)) {
-                return $template->renderBlock($name, array_merge($parameters, $this->params));
+                return $template->renderBlock($name, array_merge($this->environment->getGlobals(), $parameters, $this->params));
             }
         }
 


### PR DESCRIPTION
Hi,
adding $this->environment->getGlobals() to array_merge allows to have access to twgi gflobal variables like app.request
This is sometimes useful to get the locale or something else.
