### PR TITLE
Update grid to allow mass actions to be executed on selected rows

### DIFF
--- a/Grid/Grid.php
+++ b/Grid/Grid.php
@@ -323,7 +323,7 @@ class Grid
 
         // isReadyForRedirect ?
         if (!empty($this->requestData)) {
-						$this->executeMassActions();
+            $this->executeMassActions();
 
             if (!$this->executeExports()) {
                 $this->processRequestData();
@@ -637,10 +637,10 @@ class Grid
 
                 if($actionAllKeys)
                 {
-                	$this->processSessionData();
-                	$this->page = 0;
-                	$this->limit = 0;
-                	$this->prepare();
+                    $this->processSessionData();
+                    $this->page = 0;
+                    $this->limit = 0;
+                    $this->prepare();
                 }
 
                 if (is_callable($action->getCallback())) {


### PR DESCRIPTION
This commit allows you to execute a mass action on a filtered grid.

When adding the Mass Action, you can call `$grid->getRows()` to get the selected rows.

E.G:

```
$action = new MassAction('Action1', function($actionKeys, $actionAllKeys, $session, $params) use ($grid) {
if($actionAllKeys)
{
    $rows = $grid->getRows()
    // or
    $rows = $grid->getRawData()
}
```

This will return all the rows that was selected with the 'Select All' link.
