### PR TITLE
Doctrine hint management for Entity source

### DIFF
--- a/Grid/Source/Entity.php
+++ b/Grid/Source/Entity.php
@@ -76,6 +76,11 @@ class Entity extends Source
      */
     protected $groupBy;
 
+    /**
+     * @var array
+     */
+    protected $hints;
+
     const TABLE_ALIAS = '_a';
     const COUNT_ALIAS = '__count';
 
@@ -336,7 +341,11 @@ class Entity extends Source
         //call overridden prepareQuery or associated closure
         $this->prepareQuery($this->query);
 
-        $items = $this->query->getQuery()->getResult();
+        $query = $this->query->getQuery();
+        foreach ($this->hints as $hintKey => $hintValue) {
+            $query->setHint($hintKey, $hintValue);
+        }
+        $items = $query->getResult();
 
         // hydrate result
         $result = new Rows();
@@ -535,5 +544,15 @@ class Entity extends Source
     public function getHash()
     {
         return $this->entityName;
+    }
+
+    public function addHint($key, $value)
+    {
+        $this->hints[$key] = $value;
+    }
+    
+    public function clearHints()
+    {
+        $this->hints = array();
     }
 }


### PR DESCRIPTION
Corresponds to issue #277

DOCTRINE HINTS USAGE
Description :
When using APYDataGrid with Entity mode, it's possible to act on the final generated SQL request. For example to optimize performances. The method addHint() permits to store an array of Hint. A Hint is represented by a key and a value. Before executing request (when calling getGridResponse() method) Entity class set stored hints as Doctrine hints (keeping the array order).

Method addHint() of Entity class :
addHint(key, value) : add hint to the Entity source class.
key : key of hint
value : value of hint

Example to add USE INDEX on a table :
When building APYDatagrid :
[...]
$source = new Entity("MyBundle:Entity\MyEntity");
$source->addHint(Query::HINT_CUSTOM_OUTPUT_WALKER, "\MyPath\DoctrineExtensions\UseIndexWalker");
$source->addHint("useIndexWalker.table", "MySqlTableName");
$source->addHint("useIndexWalker.index", "MySqlIndexName");
$grid = $this->get("grid");
$grid->setSource($source);
[...]
return $grid->getGridResponse();

The Doctrine extension class (acting on SQL from clause) :
namespace MyPath\DoctrineExtensions;
use Doctrine\ORM\Query\SqlWalker;
class UseIndexWalker extends SqlWalker
{
public function walkFromClause($fromClause)
{
$sql = parent::walkFromClause($fromClause);
$table = $this->getQuery()->getHint("useIndexWalker.table");
$index = $this->getQuery()->getHint("useIndexWalker.index");
if(strpos($sql, $table))
{
$splitIndex = strpos($sql, $table) + strlen($table) + 1; // Index after the search table name.
$splitIndex += strpos(substr($sql, $splitIndex), " "); // Index after the search table alias name.
$sqlStart = substr($sql, 0, $splitIndex);
$sqlEnd = substr($sql, $splitIndex);
return $sqlStart . " USE INDEX(" . $index . ")" . $sqlEnd;
}
return $sql;
}
}

In this example, SQL request
SELECT [...] FROM MySqlTableName l0_ LEFT JOIN MyOtherSqlTableName r11_ ON [...]
is replaced by
SELECT [...] FROM MySqlTableName l0_ USE INDEX(MySqlIndexName) LEFT JOIN MyOtherSqlTableName r11_ ON [...]
