### PR TITLE
Fixing notice while setting default filters

### DIFF
--- a/Grid/Grid.php
+++ b/Grid/Grid.php
@@ -1029,7 +1029,7 @@ class Grid
                 $value = array('from' => $ColumnValue);
             }
 
-            if (array_key_exists('from', $value) && is_bool($value['from'])) {
+            if (isset($value['from']) && is_bool($value['from'])) {
                 $value['from'] = $value['from'] ? '1' : '0';
             }
 


### PR DESCRIPTION
Fixing error: 

> While setting default filter for column $grid->setDefaultFilters(array('entity.referencedEntity.id' > => array('operator' => 'isNotNull'));
> I got Notice: Undefined index: in APY/DataGridBundle/Grid/Grid.php line 1032
> if (is_bool($value['from'])) {
> $value['from'] = $value['from'] ? '1' : '0';
> }
