### PR TITLE
Make Entity source forward-compatible

### DIFF
--- a/Grid/Source/Entity.php
+++ b/Grid/Source/Entity.php
@@ -17,6 +17,7 @@ use APY\DataGridBundle\Grid\Rows;
 use APY\DataGridBundle\Grid\Row;
 use APY\DataGridBundle\Grid\Helper\ORMCountWalker;
 use Doctrine\ORM\Query;
+use Symfony\Component\HttpKernel\Kernel;
 
 class Entity extends Source
 {
@@ -101,7 +102,7 @@ class Entity extends Source
     {
         $doctrine = $container->get('doctrine');
 
-        $this->manager = method_exists($doctrine, 'getManager') ? $doctrine->getManager($this->managerName) : $doctrine->getEntityManager($this->managerName);
+        $this->manager = version_compare(Kernel::VERSION, '2.1.0', '>=') ? $doctrine->getManager($this->managerName) : $doctrine->getEntityManager($this->managerName);
         $this->ormMetadata = $this->manager->getClassMetadata($this->entityName);
 
         $this->class = $this->ormMetadata->getReflectionClass()->name;


### PR DESCRIPTION
Since Symfony 2.1, the call to doctrine `getEntityManager` is deprecated. https://github.com/doctrine/DoctrineBundle/blob/master/Registry.php#L71
