### PR TITLE
Pagination en AJAX avec PagerFanta et vue TwitterBootstrapView

### DIFF
--- a/Resources/views/blocks_js.jquery.html.twig
+++ b/Resources/views/blocks_js.jquery.html.twig
@@ -52,7 +52,7 @@ function {{ grid.hash }}_submitForm(event, form, force)
 {% block grid_scripts_ajax %}
 $(function () {
     // Order and pagerfanta links
-    $('.pagination li.disabled a').click(function (e) {
+    $('.pagination li.disabled a', '#{{ grid.hash }}').click(function (e) {
         return false;
     });
 


### PR DESCRIPTION
Hello,

Lorsque l'on met la vue TwitterBootstrapView sur Pagerfanta et que l'on souhaite faire de l'AJAX (via APYDataGridBundle::blocks_js.input.html.twig), cela ne fonctionne pas directement (le pager de TwitterBootstrap ne semple pas utiliser de nav).

Il pourrait être intéressant de supporter nativement cette vue en Ajax (d'autant plus que l'exemple de la documentation "Render a pagerfanta pager" fait appel à TwitterBootstrapView)
