### PR TITLE
Multiple grid column having "countIf" throw doctrine exception

### DIFF
--- a/Grid/Source/Entity.php
+++ b/Grid/Source/Entity.php
@@ -294,7 +294,7 @@ class Entity extends Source
                 }
 
                 if ($hasHavingClause) {
-                    $this->query->having($sub);
+                    $this->query->andHaving($sub);
                 } elseif ($isDisjunction) {
                     $where->add($sub);
                 }


### PR DESCRIPTION
fix error:
   *Invalid parameter number: number of bound variables does not match number of tokens
when having :
    \* @Grid\Column(field="client.id:countIf:1", type="boolean")
    \* @Grid\Column(field="client.id:countIf:2", type="boolean")

(On manytomany field)
