### PR TITLE
BugFix search from date type field

### DIFF
--- a/Grid/Source/Source.php
+++ b/Grid/Source/Source.php
@@ -266,7 +266,7 @@ abstract class Source implements DriverInterface
                         $value = $filter->getValue();
 
                         // Normalize value
-                        if (!$dataIsNumeric && !$value instanceof \DateTime) {
+                        if (!$dataIsNumeric && !($value instanceof \DateTime)) {
                             $value = $this->prepareStringForLikeCompare($value);
                             switch ($operator) {
                                 case Column\Column::OPERATOR_EQ:


### PR DESCRIPTION
For Vector source type, the search filter on column of date type don't work because the object of type DateTime is send to the prepareStringForLikeCompare function.
