### PR TITLE
Allow negative positions for Columns::addColumn

### DIFF
--- a/Grid/Columns.php
+++ b/Grid/Columns.php
@@ -46,13 +46,25 @@ class Columns implements \IteratorAggregate, \Countable
     {
         $column->setSecurityContext($this->securityContext);
 
-        if ($position > 0) {
-            $position--;
+        if ($position == 0) {
+
+            $this->columns[] = $column;
+
+        } else {
+
+            $newPosition = count($this->columns) + $position;
+
+            if ($position > 0) {
+                $position--;
+            } elseif ($newPosition > 0) {
+                $position = $newPosition;
+            } else {
+                $position = 0;
+            }
+
             $head = array_slice($this->columns, 0, $position);
             $tail = array_slice($this->columns, $position);
             $this->columns = array_merge($head, array($column), $tail);
-        } else {
-            $this->columns[] = $column;
         }
 
         return $this;

--- a/Resources/doc/grid_configuration/add_column.md
+++ b/Resources/doc/grid_configuration/add_column.md
@@ -3,6 +3,7 @@ Add a column
 
 You can add a column to the grid. You can fill it with the row manipulator, in your template or tell the grid what field the column will be mapped.  
 A column must be defined after the source otherwise it will always appear before the columns of the source.
+If negative column numbers are used, then the column is added that far from the last column.
 
 ## Usage
 
@@ -20,6 +21,9 @@ $grid->addColumn($MyColumn);
 
 // OR add this column to the third position
 $grid->addColumn($MyColumn, 3);
+
+// OR add this column to the next to last position
+$grid->addColumn($MyColumn, -1);
 ...
 ```
 

--- a/Tests/AddColumnTest.php
+++ b/Tests/AddColumnTest.php
@@ -1,0 +1,76 @@
+<?php
+namespace APY\DataGridBundle\Tests;
+
+use APY\DataGridBundle\Grid\Columns;
+
+class AddColumnTest extends \PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->col1 = $this->getMock('APY\DataGridBundle\Grid\Column\Column');
+        $this->col2 = $this->getMock('APY\DataGridBundle\Grid\Column\Column');
+        $this->col3 = $this->getMock('APY\DataGridBundle\Grid\Column\Column');
+        $this->newCol = $this->getMock('APY\DataGridBundle\Grid\Column\Column');
+    }
+
+    public function testAddColumnPositiveOffset()
+    {
+        $columns = $this->getBaseColumns();
+        $columns->addColumn($this->newCol, 1);
+        $this->assertAttributeEquals(array($this->newCol, $this->col1, $this->col2, $this->col3), 'columns', $columns);
+
+        $columns = $this->getBaseColumns();
+        $columns->addColumn($this->newCol, 2);
+        $this->assertAttributeEquals(array($this->col1, $this->newCol, $this->col2, $this->col3), 'columns', $columns);
+
+        $columns = $this->getBaseColumns();
+        $columns->addColumn($this->newCol, 3);
+        $this->assertAttributeEquals(array($this->col1, $this->col2, $this->newCol, $this->col3), 'columns', $columns);
+
+        $columns = $this->getBaseColumns();
+        $columns->addColumn($this->newCol, 4);
+        $this->assertAttributeEquals(array($this->col1, $this->col2, $this->col3, $this->newCol), 'columns', $columns);
+
+        $columns = $this->getBaseColumns();
+        $columns->addColumn($this->newCol, 5);
+        $this->assertAttributeEquals(array($this->col1, $this->col2, $this->col3, $this->newCol), 'columns', $columns);
+    }
+
+    public function testAddColumnNullOffset()
+    {
+        $columns = $this->getBaseColumns();
+        $columns->addColumn($this->newCol);
+        $this->assertAttributeEquals(array($this->col1, $this->col2, $this->col3, $this->newCol), 'columns', $columns);
+    }
+
+    public function testAddColumnNegativeOffset()
+    {
+        $columns = $this->getBaseColumns();
+        $columns->addColumn($this->newCol, -1);
+        $this->assertAttributeEquals(array($this->col1, $this->col2, $this->newCol, $this->col3), 'columns', $columns);
+
+        $columns = $this->getBaseColumns();
+        $columns->addColumn($this->newCol, -2);
+        $this->assertAttributeEquals(array($this->col1, $this->newCol, $this->col2, $this->col3), 'columns', $columns);
+
+        $columns = $this->getBaseColumns();
+        $columns->addColumn($this->newCol, -3);
+        $this->assertAttributeEquals(array($this->newCol, $this->col1, $this->col2, $this->col3), 'columns', $columns);
+
+        $columns = $this->getBaseColumns();
+        $columns->addColumn($this->newCol, -4);
+        $this->assertAttributeEquals(array($this->newCol, $this->col1, $this->col2, $this->col3), 'columns', $columns);
+    }
+
+    protected function getBaseColumns()
+    {
+        $context = $this->getMock('Symfony\Component\Security\Core\SecurityContextInterface');
+        $columns = new Columns($context);
+        $columns->addColumn($this->col1);
+        $columns->addColumn($this->col2);
+        $columns->addColumn($this->col3);
+        $this->assertAttributeEquals(array($this->col1, $this->col2, $this->col3), 'columns', $columns);
+        return $columns;
+    }
+}
+


### PR DESCRIPTION
Modified Columns::addColumn so that negative positions can be passed in. In this case the position is considered from the last column. So it works the same as the $offset parameter in array_slice() or the $start param of substr().

Added a "real" ;) test for it and updated the doc.
