### PR TITLE
One time prepare & prepare in mass actions

### DIFF
--- a/Grid/Grid.php
+++ b/Grid/Grid.php
@@ -464,13 +464,13 @@ class Grid
                 $actionAllKeys = (boolean)$this->getFromRequest(self::REQUEST_QUERY_MASS_ACTION_ALL_KEYS_SELECTED);
                 $actionKeys = $actionAllKeys == false ? (array) $this->getFromRequest(MassActionColumn::ID) : array();
 
+                $this->processSessionData();
                 if($actionAllKeys)
                 {
                     $this->page = 0;
                     $this->limit = 0;
                     
-                }
-                $this->processSessionData();
+                }                
                 $this->prepare();
 
                 if (is_callable($action->getCallback())) {


### PR DESCRIPTION
One time prepare
- added $prepared attribute to indicate if prepare() was done
- if $prepared prepare() exits on begin

Prepare in mass actions
- processSessionData() and prepare() is always called (not only for actionAllKeys) in processMassActions() to enable accessing filtered grid data.
