### PR TITLE
Move grid.mapping.manager service to prototype scope

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -46,7 +46,7 @@
             <argument type="service" id="annotation_reader" />
         </service>
 
-        <service id="grid.mapping.manager" class="APY\DataGridBundle\Grid\Mapping\Metadata\Manager">
+        <service id="grid.mapping.manager" class="APY\DataGridBundle\Grid\Mapping\Metadata\Manager" scope="prototype">
             <argument type="service" id="form.factory"/>
             <call method="addDriver">
                 <argument type="service" id="grid.metadata.driver.annotation" />


### PR DESCRIPTION
See issue #399 for more details, but this will fix certain issues that can arise from having it as container scope versus prototype.
