### PR TITLE
Fix #403

### DIFF
--- a/Grid/Export/ExcelExport.php
+++ b/Grid/Export/ExcelExport.php
@@ -31,7 +31,7 @@ class ExcelExport extends Export
         if (isset($data['titles'])) {
             $this->content .= '<tr>';
             foreach ($data['titles'] as $title) {
-                $this->content .= "<th>$title</th>";
+                $this->content .= sprintf("<th>%s</th>", htmlentities($title, ENT_QUOTES));
             }
             $this->content .= '</tr>';
         }
@@ -39,7 +39,7 @@ class ExcelExport extends Export
         foreach ($data['rows'] as $row) {
             $this->content .= '<tr>';
             foreach ($row as $cell) {
-                $this->content .= "<td>$cell</td>";
+                $this->content .= sprintf("<td>%s</td>", htmlentities($cell, ENT_QUOTES));
             }
             $this->content .= '</tr>';
         }

--- a/Grid/Export/Export.php
+++ b/Grid/Export/Export.php
@@ -453,7 +453,7 @@ abstract class Export implements ExportInterface, ContainerAwareInterface
         $value = strip_tags($value);
 
         // Convert Special Characters in HTML
-        $value = html_entity_decode($value);
+        $value = html_entity_decode($value, ENT_QUOTES);
 
         // Trim
         $value = trim($value);


### PR DESCRIPTION
This fixes the quote issue in all exports which were always escaped in the superclass (&# 39).

And fixes the issue with some characters in native excel export (< for example).

Are you OK with this ?
