### PR TITLE
Add documentation for installation via composer

### DIFF
--- a/Resources/doc/installation.md
+++ b/Resources/doc/installation.md
@@ -54,7 +54,7 @@ $ git submodule add git://github.com/Abhoryo/APYDataGridBundle.git vendor/bundle
 $ git submodule update --init
 ```
 
-### Step 2: Configure the Autoloader
+### Step 2: Configure the Autoloader (not needed for composer)
 
 Add the `APY` namespace to your autoloader:
 


### PR DESCRIPTION
Hi,

Here is some documentation for bundle installation via Composer (more symfony 2.2 friendly).

Ultimately, we should remove the sections about bin/vendors (which is obsolete for sf 2.1+) and submodules, and remove the Step 2 (not needed for composer)
