### PR TITLE
Allow to specify join type on related tables

### DIFF
--- a/Grid/Column/Column.php
+++ b/Grid/Column/Column.php
@@ -87,6 +87,7 @@ abstract class Column
     protected $searchOnClick = false;
     protected $safe;
     protected $separator;
+    protected $joinType;
 
     protected $dataJunction = self::DATA_CONJUNCTION;
 
@@ -117,6 +118,7 @@ abstract class Column
         $this->setField($this->getParam('field'));
         $this->setRole($this->getParam('role'));
         $this->setOrder($this->getParam('order'));
+        $this->setJoinType($this->getParam('joinType'));
         $this->setFilterType($this->getParam('filter', 'input'));
         $this->setSelectFrom($this->getParam('selectFrom', 'query'));
         $this->setValues($this->getParam('values', array()));
@@ -835,5 +837,15 @@ abstract class Column
     public function getSeparator()
     {
         return $this->separator;
+    }
+
+    public function setJoinType($type)
+    {
+        $this->joinType = $type;
+    }
+
+    public function getJoinType()
+    {
+        return $this->joinType;
     }
 }

--- a/Grid/Source/Entity.php
+++ b/Grid/Source/Entity.php
@@ -155,7 +155,7 @@ class Entity extends Source
                 if (count($elements) > 0) {
                     $parent = ($previousParent == '') ? $this->getTableAlias() : $previousParent;
                     $previousParent .= '_' . $element;
-                    $this->joins[$previousParent] = $parent . '.' . $element;
+                    $this->joins[$previousParent] = array('field' => $parent . '.' . $element, 'type' => $column->getJoinType());
                 } else {
                     $name = $previousParent . '.' . $element;
                 }
@@ -366,8 +366,14 @@ class Entity extends Source
         }
 
         foreach ($this->joins as $alias => $field) {
-            $this->query->leftJoin($field, $alias);
-            $this->querySelectfromSource->leftJoin($field, $alias);
+            if(null !== $field['type'] && strtolower($field['type']) === 'inner') {
+                $join = 'join';
+            } else {
+                $join = 'leftJoin';
+            }
+
+            $this->query->$join($field['field'], $alias);
+            $this->querySelectfromSource->$join($field['field'], $alias);
         }
 
         if ($page > 0) {

--- a/Resources/doc/columns_configuration/annotations/association_mapping.md
+++ b/Resources/doc/columns_configuration/annotations/association_mapping.md
@@ -53,13 +53,39 @@ class Category
 }
 ```
 
-A column on a mapped field has the same attributes of a normal field and have one another attribute: `field`
+**Important** Fields are automitically joined with a leftJoin. If you want to use an inner join, you can specify the join type:
+
+```php
+<?php
+...
+class Product
+{
+    protected $id;
+
+    protected $type;
+
+    /**
+     * @ORM\OneToMany(...)
+     *
+     * @GRID\Column(field="category.name", title="Category Name", joinType="inner")
+     */
+    protected $category;
+...
+}
+```
+
+**Important**: With mapped fields, the guess typing is not implemented, you need to explicitly define the type if it's not a text field.
+
+
+A column on a mapped field has the same attributes of a normal field and have two another attribute: `field` and `joinType`
+
 
 ### Additionnal Attribute:
 
 |Attribute|Type|Default value|Possible values|Description|
 |:--:|:--|:--|:--|:--|
 |field|string|||The name of the related field of the property|
+|joinType|string||inner|Specify the join type for the related records (E.G. 'inner' for an inner join|
 
 **Note**: The default title of a related field is the name of the field.
 `@Grid\Column(field="category.name") => title = "category.name"`


### PR DESCRIPTION
By default the grid uses a leftJoin when joining related tables.

If you have 2 entities, one for authors, and one for books, and you want to display a grid with books and show the author name, you would use the following annotation:

```
/**
 * @Grid\Column(field="author.name")
 */
 private $author;
```

If you use the [`SoftDeletableBehavior`](https://github.com/l3pp4rd/DoctrineExtensions/blob/master/doc/softdeleteable.md), and you delete an author, the record still shows in the books grid with no author.

This change allows you to set the join type to an inner join, so it won't display book records that have no author

```
/**
 * @Grid\Column(field="author.name", joinType="inner")
 */
 private $author;
```
