### PR TITLE
Fix pager visibility check

### DIFF
--- a/Grid/Grid.php
+++ b/Grid/Grid.php
@@ -1651,7 +1651,7 @@ class Grid
     public function isPagerSectionVisible()
     {
         // true when totalCount rows exceed the minimum pager limit
-        return (min($this->getLimits()) <= $this->totalCount);
+        return (min(array_keys($this->getLimits())) <= $this->totalCount);
     }
 
     /**


### PR DESCRIPTION
Should calculate minimum value for the keys, which is actually the limit, instead of the value, which is just the label
