### PR TITLE
Allow to give a name when adding an attribute

### DIFF
--- a/Grid/Action/RowAction.php
+++ b/Grid/Action/RowAction.php
@@ -281,13 +281,14 @@ class RowAction implements RowActionInterface
     /**
      * Add attribute
      *
-     * @param array $attribute
+     * @param string $name
+     * @param string $value
      *
      * @return self
      */
-    public function addAttribute($attribute)
+    public function addAttribute($name, $value)
     {
-        $this->attributes[] = $attribute;
+        $this->attributes[$name] = $value;
 
         return $this;
     }


### PR DESCRIPTION
Hi,

Currently when adding attributes to RowAction with the addAttribute() method, you can't give the name of the attribute  you want to add. The template currently renders the attribute with name 0, 1, 2 etc.. 

I don't think anyone is using it right now !

What do you think ?

PS : We can also raise an exception if the name already exists
