### PR TITLE
no params array available - use imgDir directly

### DIFF
--- a/Resources/doc/template/cell_rendering.md
+++ b/Resources/doc/template/cell_rendering.md
@@ -42,7 +42,7 @@ grid(grid, 'MyProjectMyBundle::my_grid_template.html.twig', '', {'imgDir': 'img/
 {% extends 'APYDataGridBundle::blocks.html.twig' %}
 
 {% block grid_column_boolean_cell %}
-    <img src="{{ assets(params.imgDir ~ value ~ '.jpg')}}" alt="{{ value }}" />
+    <img src="{{ assets(imgDir ~ value ~ '.jpg')}}" alt="{{ value }}" />
 {% endblock grid_column_boolean_cell %}
 ```
 
@@ -57,7 +57,7 @@ grid(grid, 'MyProjectMyBundle::my_grid_template.html.twig', '', {'imgDir': 'img/
 {% extends 'APYDataGridBundle::blocks.html.twig' %}
 
 {% block grid_column_boolean_cell %}
-    {% set value = '<img src="'~assets(params.imgDir ~ value ~ '.jpg')~'" alt="~value~" />' %}
+    {% set value = '<img src="'~assets(imgDir ~ value ~ '.jpg')~'" alt="~value~" />' %}
     {{ block('grid_column_cell') }}
 {% endblock grid_column_boolean_cell %}
 ```


### PR DESCRIPTION
If you call the grid function in a template with additional parameters these parameters are injected directly into the block, see https://github.com/Abhoryo/APYDataGridBundle/blob/master/Twig/DataGridExtension.php?source=cc#L313

`return $template->renderBlock($name, array_merge($this->environment->getGlobals(), $parameters, $this->params));`

So there won't be a params array as shown in the example.
