### PR TITLE
Fix trans() extraction errors

### DIFF
--- a/Grid/Export/Export.php
+++ b/Grid/Export/Export.php
@@ -284,7 +284,7 @@ abstract class Export implements ExportInterface, ContainerAwareInterface
         $titles = array();
         foreach ($this->grid->getColumns() as $column) {
             if ($column->isVisible(true)) {
-                $titles[] = utf8_decode($translator->trans($column->getTitle()));
+                $titles[] = utf8_decode($translator->trans(/** @Ignore */$column->getTitle()));
             }
         }
 


### PR DESCRIPTION
Add /*\* @Ignore */ inside call to trans() on line 287 to fix errors occurring when extracting translations due to a method being passed as the argument instead of a string (Which is what trans() expects)
