### PR TITLE
Fixed bug with unused grid route parameters

### DIFF
--- a/Resources/views/blocks.html.twig
+++ b/Resources/views/blocks.html.twig
@@ -223,7 +223,7 @@
     {% set actions = column.getActionsToRender(row) %}
     <ul class="grid-row-actions">
     {% for action in actions %}
-        <li><a href="{{ url(action.route, column.routeParameters(row, action), false) }}" target="{{ action.target }}"{% if action.confirm %} onclick="return confirm('{{ action.confirmMessage }}')"{% endif %}{% for name, value in action.attributes %} {{ name }}="{{ value }}" {% endfor %}>{{ action.title|trans }}</a></li>
+        <li><a href="{{ url(action.route, grid.routeParameters|merge(column.routeParameters(row, action)), false) }}" target="{{ action.target }}"{% if action.confirm %} onclick="return confirm('{{ action.confirmMessage }}')"{% endif %}{% for name, value in action.attributes %} {{ name }}="{{ value }}" {% endfor %}>{{ action.title|trans }}</a></li>
     {% endfor %}
     </ul>
 {% endblock grid_column_actions_cell %}


### PR DESCRIPTION
I dont know for what the grid need a route if not for this... :+1: 

Example why I need that:

**Controller**

``` php
<?php
use APY\DataGridBundle\Grid\Action\RowAction;
use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
use Sensio\Bundle\FrameworkExtraBundle\Configuration\ParamConverter;
use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
use Symfony\Bundle\FrameworkBundle\Controller\Controller;
use Acme\DemoBundle\Entity\Company;
use Acme\DemoBundle\Entity\Branch;
/**
 * Class CompanyBranchController
 * @Route("/{company}/branch", requirements={"company" = "\d+"})
 * @ParamConverter("item", class="AcmeDemoBundle:Company", options={"id"="company"})
 */
class CompanyBranchController extends Controller
{
    /**
     * @Route("/list", name="route_for_list")
     * @Template
     */
    public function listAction(Company $item = null)
    {
        $source = new Entity('AcmeDemoBundle:Company');

        /** @var $grid \APY\DataGridBundle\Grid\Grid */
        $grid = $this->get('grid');
        $grid->setSource($source);
        $grid->setRouteParameter('company', $item instanceof Company ? $item->getId() : 0);

        // Specify route parameters for the edit action
        $rowAction2 = new RowAction('Edit', 'route_to_edit');
        $rowAction2->setRouteParameters(array('id', 'company.id'));
        $rowAction2->setRouteParametersMapping(array('company.id' => 'company'));
        $grid->addRowAction($rowAction2);
    }
```

The examples throw...

```
An exception has been thrown during the rendering of a template
("Parameter "company" for route "route_for_list" must match "\d+" ("" given) to generate a corresponding URL.")
```

If i use the patch it would work without this:

``` php
        $rowAction2->setRouteParameters(array('id', 'company.id'));
        $rowAction2->setRouteParametersMapping(array('company.id' => 'company'));
```

Then your grid uses the default "id" field for the edit route and the company field for the branches.

**Example usage:**

``` php
...
    /**
     * @Route("/edit/{id}", name="route_to_edit")
     * @Template
     */
    public function editAction($id)
    {
        /** @var $company Company */
        $company = $this->getRequest()->get('company');

        /** @var $branch Branch */
        $branch = $this->getDoctrine()->getRepository('AcmeDemoBundle:CompanyBranch')->find($id);
        ...
    }
...
```

**php app/console router:debug**

```
route_for_list    ANY      ANY    ANY  /{company}/branch/list
route_to_edit     ANY      ANY    ANY  /{company}/branch/edit/{id}
```

Thank's.
