### PR TITLE
Add hasColumn method to Grid in order to check if a column exists in bot...

### DIFF
--- a/Grid/Grid.php
+++ b/Grid/Grid.php
@@ -1027,6 +1027,23 @@ class Grid
     }
 
     /**
+     * Returns true if column exists in columns and lazyAddColumn properties
+     *
+     * @param $columnId
+     * @return boolean
+     */
+    public function hasColumn($columnId)
+    {
+        foreach ($this->lazyAddColumn as $column) {
+            if ($column['column']->getId() == $columnId) {
+                return true;
+            }
+        }
+
+        return $this->columns->hasColumnById($columnId);
+    }
+
+    /**
      * Sets Array of Columns to the grid
      *
      * @param $columns


### PR DESCRIPTION
...h 'columns' and 'lazyAddColumn' properties before processLazyParameters is called

Because i need to check if a virtual column exists before getGridResponse is called.
