### PR TITLE
Update blank_column.md

### DIFF
--- a/Resources/doc/columns_configuration/types/blank_column.md
+++ b/Resources/doc/columns_configuration/types/blank_column.md
@@ -41,9 +41,9 @@ $grid->addColumn($MyColumn);
 
 ```django
 {% block grid_column_informations_cell %}
-{{ grid.field('column4') }}
+{{ row.field('column4') }}
 <br />
-{{ grid.field('column5') }}
+{{ row.field('column5') }}
 {% endblock grid_column_informations_cell %}
 ```
 


### PR DESCRIPTION
The `field()` method does not exist on the grid object, `row.field()` should be used instead
