### PR TITLE
Fixed small spelling mistakes in French translation

### DIFF
--- a/Resources/translations/messages.fr.xliff
+++ b/Resources/translations/messages.fr.xliff
@@ -40,7 +40,7 @@
             </trans-unit>
             <trans-unit id="10">
                 <source>Submit Action</source>
-                <target>Éxecuter</target>
+                <target>Exécuter</target>
             </trans-unit>
             <trans-unit id="11">
                 <source>From:</source>
@@ -52,7 +52,7 @@
             </trans-unit>
             <trans-unit id="13">
                 <source>eq</source>
-                <target>Égale à</target>
+                <target>Égal à</target>
             </trans-unit>
             <trans-unit id="14">
                 <source>neq</source>
@@ -64,7 +64,7 @@
             </trans-unit>
             <trans-unit id="16">
                 <source>lte</source>
-                <target>Inférieur ou égale à</target>
+                <target>Inférieur ou égal à</target>
             </trans-unit>
             <trans-unit id="17">
                 <source>gt</source>
@@ -72,7 +72,7 @@
             </trans-unit>
             <trans-unit id="18">
                 <source>gte</source>
-                <target>Supérieur ou égale à</target>
+                <target>Supérieur ou égal à</target>
             </trans-unit>
             <trans-unit id="19">
                 <source>req</source>
@@ -92,7 +92,7 @@
             </trans-unit>
             <trans-unit id="23">
                 <source>llike</source>
-                <target>Fini par</target>
+                <target>Finit par</target>
             </trans-unit>
             <trans-unit id="24">
                 <source>btw</source>


### PR DESCRIPTION
"égal" as an adjective is without '-e' (unless feminine), and "finit" as a verb takes a '-t'.
Also, there should probably be a space before ':' (in "De :" and "À :"), but you could choose differently on that one so I leave it to you.
