### PR TITLE
Add useGridPrefix property to column

### DIFF
--- a/Grid/Column/Column.php
+++ b/Grid/Column/Column.php
@@ -91,7 +91,7 @@ abstract class Column
     protected $class;
     protected $isManualField;
     protected $isAggregate;
-    protected $useGridPrefix;
+    protected $usePrefixTitle;
 
     protected $dataJunction = self::DATA_CONJUNCTION;
 
@@ -129,7 +129,7 @@ abstract class Column
         $this->setOperatorsVisible($this->getParam('operatorsVisible', true));
         $this->setIsManualField($this->getParam('isManualField', false));
         $this->setIsAggregate($this->getParam('isAggregate', false));
-        $this->setUseGridPrefix($this->getParam('useGridPrefix', true));
+        $this->setUsePrefixTitle($this->getParam('usePrefixTitle', true));
         
         // Order is important for the order display
         $this->setOperators($this->getParam('operators', array(
@@ -901,14 +901,14 @@ abstract class Column
         return $this->isAggregate;
     }
 
-    public function getUseGridPrefix()
+    public function getUsePrefixTitle()
     {
-        return $this->useGridPrefix;
+        return $this->usePrefixTitle;
     }
 
-    public function setUseGridPrefix($useGridPrefix)
+    public function setUsePrefixTitle($usePrefixTitle)
     {
-        $this->useGridPrefix = $useGridPrefix;
+        $this->usePrefixTitle = $usePrefixTitle;
         return $this;
     }
  

--- a/Resources/doc/columns_configuration/annotations/column_annotation_property.md
+++ b/Resources/doc/columns_configuration/annotations/column_annotation_property.md
@@ -64,7 +64,7 @@ class Product
 |values|array|_none_||For select filters or replace values in the grid|
 |searchOnClick|boolean|false|true or false|Sets the possibility to perform a search on the clicked cell (filterable has to be true)|
 |safe|string or false|html|false<br />or<br />see [Escape filters](http://twig.sensiolabs.org/doc/filters/escape.html)|Sets the escape filter|
-|useGridPrefix|boolean|true|true or false|Use the prefixTitle of the grid to render title|
+|usePrefixTitle|boolean|true|true or false|Use the prefixTitle of the grid to render title|
 **Note 1**: Every attribute has a setter and a getter method.  
 **Note 2**: With the `values` attributes, if `type1` is found, the grid displays the value `Type 1`.  
 **Note 3**: If operators are not visible, filtering is performed with the default operator.

--- a/Resources/views/blocks.html.twig
+++ b/Resources/views/blocks.html.twig
@@ -64,8 +64,8 @@
             {%- spaceless %}
             {% if column.type == 'massaction' %}
                 <input type="checkbox" class="grid-mass-selector" onclick="{{ grid.hash }}_markVisible(this.checked);"/>
-            {% else %}
-                {% if column.useGridPrefix == true %}
+            {% else %} 
+                {% if column.usePrefixTitle == true %}
                     {% set columnTitle = grid.prefixTitle ~ column.title ~ '__abbr' %}
                     {% if columnTitle|trans == columnTitle %}
                         {% set columnTitle = grid.prefixTitle ~ column.title %}
@@ -107,7 +107,7 @@
         <form id="{{ grid.hash }}_search" action="{{ grid.routeUrl }}" method="post">
         {% for column in grid.columns %}
             {% if column.isFilterable and column.type not in ['actions', 'massaction'] %}
-                {% if column.useGridPrefix == true %}
+                {% if column.usePrefixTitle == true %}
                     {% set columnTitle = grid.prefixTitle ~ column.title %}
                 {% else %}
                     {% set columnTitle = column.title %}


### PR DESCRIPTION
This property allow to use or not the grid prefixTitle for a column when rendering the template. It is useful when adding dynamic columns from database when the title cannot be translated statically.
