### PR TITLE
Fix ReferenceOne mapping columns for mongoODM

### DIFF
--- a/Grid/Column/ArrayColumn.php
+++ b/Grid/Column/ArrayColumn.php
@@ -36,37 +36,41 @@ class ArrayColumn extends Column
         $parentFilters = parent::getFilters($source);
 
         $filters = array();
-        foreach($parentFilters as $filter) {
-            switch ($filter->getOperator()) {
-                case self::OPERATOR_EQ:
-                case self::OPERATOR_NEQ:
-                    $filterValues = (array) $filter->getValue();
-                    $value = '';
-                    $counter = 1;
-                    foreach ($filterValues as $filterValue) {
-                        $len = strlen($filterValue);
-                        $value .= 'i:'.$counter++.';s:'.$len.':"'.$filterValue.'";';
-                    }
+        foreach ($parentFilters as $filter) {
+            if ($source === "document") {
+                $filters[] = $filter;
+            } else {
+                switch ($filter->getOperator()) {
+                    case self::OPERATOR_EQ:
+                    case self::OPERATOR_NEQ:
+                        $filterValues = (array) $filter->getValue();
+                        $value = '';
+                        $counter = 1;
+                        foreach ($filterValues as $filterValue) {
+                            $len = strlen($filterValue);
+                            $value .= 'i:' . $counter++ . ';s:' . $len . ':"' . $filterValue . '";';
+                        }
 
-                    $filters[] =  new Filter($filter->getOperator(), 'a:'.count($filterValues).':{'.$value.'}');
-                    break;
-                case self::OPERATOR_LIKE:
-                case self::OPERATOR_NLIKE:
-                    $len = strlen($filter->getValue());
-                    $value = 's:'.$len.':"'.$filter->getValue().'";';
-                    $filters[] =  new Filter($filter->getOperator(), $value);
-                    break;
-                case self::OPERATOR_ISNULL:
-                    $filters[] =  new Filter(self::OPERATOR_ISNULL);
-                    $filters[] =  new Filter(self::OPERATOR_EQ, 'a:0:{}');
-                    $this->setDataJunction(self::DATA_DISJUNCTION);
-                    break;
-                case self::OPERATOR_ISNOTNULL:
-                    $filters[] =  new Filter(self::OPERATOR_ISNOTNULL);
-                    $filters[] =  new Filter(self::OPERATOR_NEQ, 'a:0:{}');
-                    break;
-                default:
-                    $filters[] = $filter;
+                        $filters[] = new Filter($filter->getOperator(), 'a:' . count($filterValues) . ':{' . $value . '}');
+                        break;
+                    case self::OPERATOR_LIKE:
+                    case self::OPERATOR_NLIKE:
+                        $len = strlen($filter->getValue());
+                        $value = 's:' . $len . ':"' . $filter->getValue() . '";';
+                        $filters[] = new Filter($filter->getOperator(), $value);
+                        break;
+                    case self::OPERATOR_ISNULL:
+                        $filters[] = new Filter(self::OPERATOR_ISNULL);
+                        $filters[] = new Filter(self::OPERATOR_EQ, 'a:0:{}');
+                        $this->setDataJunction(self::DATA_DISJUNCTION);
+                        break;
+                    case self::OPERATOR_ISNOTNULL:
+                        $filters[] = new Filter(self::OPERATOR_ISNOTNULL);
+                        $filters[] = new Filter(self::OPERATOR_NEQ, 'a:0:{}');
+                        break;
+                    default:
+                        $filters[] = $filter;
+                }
             }
         }
 
@@ -80,9 +84,9 @@ class ArrayColumn extends Column
         }
 
         $return = array();
-        if(is_array($values) || $values instanceof \Traversable) {
+        if (is_array($values) || $values instanceof \Traversable) {
             foreach ($values as $key => $value) {
-                if (!is_array($value) && isset($this->values[(string)$value])) {
+                if (!is_array($value) && isset($this->values[(string) $value])) {
                     $value = $this->values[$value];
                 }
 

--- a/Grid/Grid.php
+++ b/Grid/Grid.php
@@ -13,17 +13,16 @@
 
 namespace APY\DataGridBundle\Grid;
 
-use Symfony\Component\HttpFoundation\RedirectResponse;
-use Symfony\Component\HttpFoundation\Response;
-use Symfony\Component\DependencyInjection\ContainerAwareInterface;
-
 use APY\DataGridBundle\Grid\Action\MassActionInterface;
 use APY\DataGridBundle\Grid\Action\RowActionInterface;
+use APY\DataGridBundle\Grid\Column\ActionsColumn;
 use APY\DataGridBundle\Grid\Column\Column;
 use APY\DataGridBundle\Grid\Column\MassActionColumn;
-use APY\DataGridBundle\Grid\Column\ActionsColumn;
-use APY\DataGridBundle\Grid\Source\Source;
 use APY\DataGridBundle\Grid\Export\ExportInterface;
+use APY\DataGridBundle\Grid\Source\Source;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
 
 class Grid
 {
@@ -90,7 +89,7 @@ class Grid
     /**
      * @var boolean
      */
-     protected $prepared = false;
+    protected $prepared = false;
 
     /**
      * @var int
@@ -338,6 +337,7 @@ class Grid
      */
     public function isReadyForRedirect()
     {
+
         if ($this->source === null) {
             throw new \Exception('The source of the grid is not set.');
         }
@@ -383,7 +383,7 @@ class Grid
 
     protected function getCurrentUri()
     {
-        return $this->request->getScheme().'://'.$this->request->getHttpHost().$this->request->getBaseUrl().$this->request->getPathInfo();
+        return $this->request->getScheme() . '://' . $this->request->getHttpHost() . $this->request->getBaseUrl() . $this->request->getPathInfo();
     }
 
     protected function processPersistence()
@@ -392,7 +392,7 @@ class Grid
 
         // Persistence or reset - kill previous session
         if ((!$this->request->isXmlHttpRequest() && !$this->persistence && $referer != $this->getCurrentUri())
-         || isset($this->requestData[self::REQUEST_QUERY_RESET])) {
+            || isset($this->requestData[self::REQUEST_QUERY_RESET])) {
             $this->session->remove($this->hash);
         }
 
@@ -467,13 +467,13 @@ class Grid
         if ($actionId > -1 && '' !== $actionId) {
             if (array_key_exists($actionId, $this->massActions)) {
                 $action = $this->massActions[$actionId];
-                $actionAllKeys = (boolean)$this->getFromRequest(self::REQUEST_QUERY_MASS_ACTION_ALL_KEYS_SELECTED);
+                $actionAllKeys = (boolean) $this->getFromRequest(self::REQUEST_QUERY_MASS_ACTION_ALL_KEYS_SELECTED);
                 $actionKeys = $actionAllKeys == false ? (array) $this->getFromRequest(MassActionColumn::ID) : array();
 
                 $this->processSessionData();
                 if ($actionAllKeys) {
                     $this->page = 0;
-                    $this->limit = 0;
+                    $this->limit = 1;
                 }
                 $this->prepare();
 
@@ -482,9 +482,9 @@ class Grid
                 } elseif (strpos($action->getCallback(), ':') !== false) {
                     $path = array_merge(
                         array(
-                            'primaryKeys'    => array_keys($actionKeys),
+                            'primaryKeys' => array_keys($actionKeys),
                             'allPrimaryKeys' => $actionAllKeys,
-                            '_controller'    => $action->getCallback()
+                            '_controller' => $action->getCallback(),
                         ),
                         $action->getParameters()
                     );
@@ -671,9 +671,9 @@ class Grid
     {
         // Set to the first page if this is a request of order, limit, mass action or filtering
         if ($this->getFromRequest(self::REQUEST_QUERY_ORDER) !== null
-         || $this->getFromRequest(self::REQUEST_QUERY_LIMIT) !== null
-         || $this->getFromRequest(self::REQUEST_QUERY_MASS_ACTION) !== null
-         || $filtering) {
+            || $this->getFromRequest(self::REQUEST_QUERY_LIMIT) !== null
+            || $this->getFromRequest(self::REQUEST_QUERY_MASS_ACTION) !== null
+            || $filtering) {
             $this->set(self::REQUEST_QUERY_PAGE, 0);
         } else {
             $this->set(self::REQUEST_QUERY_PAGE, $page);
@@ -744,7 +744,7 @@ class Grid
         $this->saveSession();
     }
 
-     /**
+    /**
      * Store permanent filters to the session and disable the filter capability for the column if there are permanent filters
      */
     protected function processFilters($permanent = true)
@@ -975,7 +975,7 @@ class Grid
 
     protected function createHash()
     {
-        $this->hash = 'grid_'. (empty($this->id) ? md5($this->request->get('_controller').$this->columns->getHash().$this->source->getHash()) : $this->getId());
+        $this->hash = 'grid_' . (empty($this->id) ? md5($this->request->get('_controller') . $this->columns->getHash() . $this->source->getHash()) : $this->getId());
     }
 
     public function getHash()
@@ -1133,11 +1133,11 @@ class Grid
      */
     public function getTweaks()
     {
-        $separator =  strpos($this->getRouteUrl(), '?') ? '&' : '?';
-        $url = $this->getRouteUrl().$separator.$this->getHash().'['.Grid::REQUEST_QUERY_TWEAK.']=';
+        $separator = strpos($this->getRouteUrl(), '?') ? '&' : '?';
+        $url = $this->getRouteUrl() . $separator . $this->getHash() . '[' . Grid::REQUEST_QUERY_TWEAK . ']=';
 
         foreach ($this->tweaks as $id => $tweak) {
-            $this->tweaks[$id] = array_merge($tweak, array('url' => $url.$id));
+            $this->tweaks[$id] = array_merge($tweak, array('url' => $url . $id));
         }
 
         return $this->tweaks;
@@ -1440,7 +1440,6 @@ class Grid
         return $this->id;
     }
 
-
     /**
      * Sets persistence
      *
@@ -1489,13 +1488,13 @@ class Grid
     public function setLimits($limits)
     {
         if (is_array($limits)) {
-            if ((int)key($limits) === 0) {
+            if ((int) key($limits) === 0) {
                 $this->limits = array_combine($limits, $limits);
             } else {
                 $this->limits = $limits;
             }
         } elseif (is_int($limits)) {
-            $this->limits = array($limits => (string)$limits);
+            $this->limits = array($limits => (string) $limits);
         } else {
             throw new \InvalidArgumentException('Limit has to be array or integer');
         }
@@ -1576,7 +1575,7 @@ class Grid
      */
     public function setPage($page)
     {
-        if ((int)$page >= 0) {
+        if ((int) $page >= 0) {
             $this->page = (int) $page;
         } else {
             throw new \InvalidArgumentException('Page must be a positive number');
@@ -1594,7 +1593,6 @@ class Grid
     {
         return $this->page;
     }
-
 
     /**
      * Returnd grid display data as rows - internal helper for templates

--- a/Grid/Source/Document.php
+++ b/Grid/Source/Document.php
@@ -142,8 +142,8 @@ class Document extends Source
                 return new \MongoRegex('/'.$value.'$/i');
             case Column::OPERATOR_SLIKE:
                 return new \MongoRegex('/'.$value.'/');
-//            case Column::OPERATOR_SLIKE:
-//                return new \MongoRegex('/^((?!'.$value.').)*$/');
+            case Column::OPERATOR_SLIKE:
+               return new \MongoRegex('/^((?!'.$value.').)*$/');
             case Column::OPERATOR_RSLIKE:
                 return new \MongoRegex('/^'.$value.'/');
             case Column::OPERATOR_LSLIKE:

--- a/Grid/Source/Document.php
+++ b/Grid/Source/Document.php
@@ -156,7 +156,6 @@ class Document extends Source
         $this->query = $this->manager->createQueryBuilder($this->documentName);
 
         foreach ($columns as $column) {
-            $this->query->select($column->getField());
 
             //checks if exists '.' notation on referenced columns and build query if it's filtered
             $subColumn = explode('.', $column->getId());
@@ -167,6 +166,8 @@ class Document extends Source
 
                 continue;
             }
+
+            $this->query->select($column->getField());
 
             if ($column->isSorted()) {
                 $this->query->sort($column->getField(), $column->getOrder());
@@ -276,7 +277,7 @@ class Document extends Source
 
     /**
      * @param \APY\DataGridBundle\Grid\Row    $row
-     * @param \stdClass $resource
+     * @param Document $resource
      * @throws \Exception if getter for field does not exists
      * @return \APY\DataGridBundle\Grid\Row $row with referenced fields
      */

--- a/Grid/Source/Document.php
+++ b/Grid/Source/Document.php
@@ -223,8 +223,8 @@ class Document extends Source
             $properties = $this->getClassProperties($resource);
 
             foreach ($columns as $column) {
-                if (isset($properties[$column->getId()])) {
-                    $row->setField($column->getId(), $properties[$column->getId()]);
+                if (isset(strtolower($properties[$column->getId())])) {
+                    $row->setField($column->getId(), $properties[strtolower($column->getId())]);
                 }
             }
 

--- a/Grid/Source/Document.php
+++ b/Grid/Source/Document.php
@@ -125,7 +125,7 @@ class Document extends Source
     {
         switch ($operator) {
             case Column::OPERATOR_EQ:
-                return new \MongoRegex('/^' . $value . '$/i');
+                return $value;
             case Column::OPERATOR_NEQ:
                 return new \MongoRegex('/^(?!' . $value . '$).*$/i');
             case Column::OPERATOR_LIKE:

--- a/Grid/Source/Document.php
+++ b/Grid/Source/Document.php
@@ -223,7 +223,7 @@ class Document extends Source
             $properties = $this->getClassProperties($resource);
 
             foreach ($columns as $column) {
-                if (isset(strtolower($properties[$column->getId())])) {
+                if (isset($properties[strtolower($column->getId())])) {
                     $row->setField($column->getId(), $properties[strtolower($column->getId())]);
                 }
             }

--- a/Resources/translations/messages.pl.xliff
+++ b/Resources/translations/messages.pl.xliff
@@ -64,7 +64,7 @@
             </trans-unit>
             <trans-unit id="28">
                 <source>%count% Results, </source>
-                <target>%count% Wynik, |%count% Wyników, </target>
+                <target>{0} %count% Wyników|{1} %count% Wynik|]1,Inf[ %count% Wyników, </target>
             </trans-unit>
 
             <trans-unit id="1">


### PR DESCRIPTION
Document notation must be:
```php
/**
 * @MongoDB\Document
 * @GRID\Source(columns="id, referenceColumn, referenceColumn.name")
 */
class DocumentExample
.
.
.
/**
  * @MongoDB\ReferenceOne(targetDocument="referenceDocument")
  * @GRID\Column(field="referenceColumn", visible=false)
  * @GRID\Column(field="referenceColumn.name", sortable=false)
  */
    private $referenceColumn;
```
Showing and filtering by column referenceColumn.name works fine.