### PR TITLE
[DX] Add block to set custom class on table tag

### DIFF
--- a/Resources/views/blocks.html.twig
+++ b/Resources/views/blocks.html.twig
@@ -9,7 +9,7 @@
         {% endif %}
         </div>
         <div class="grid_body">
-        <table>
+        <table class-"{% block table_class %}{% endblock %}">
         {% if grid.isTitleSectionVisible %}
             {{ grid_titles(grid) }}
         {% endif %}


### PR DESCRIPTION
Must override all grid block to add a class to the table tag. This simplifies the developer experience to use [Bootstrap 3](http://getbootstrap.com/css/#tables) for example.
To avoid leaving the default empty class attribute, you can initialize it with the value "grid_table".