### PR TITLE
grid_column_array_cell more like implode

### DIFF
--- a/Resources/views/blocks.html.twig
+++ b/Resources/views/blocks.html.twig
@@ -263,7 +263,10 @@
 {% for key, index in values -%}
     {% set value = index %}
     {% set sourceValue = sourceValues[key] %}
-    {{ block('grid_column_cell') | raw }}{{ column.separator | raw }}
+    {{ block('grid_column_cell') | raw }}
+    {% if not loop.last %}
+      {{ column.separator | raw }}
+    {% endif %}
 {%- endfor %}
 {% endblock grid_column_array_cell %}
 {% block grid_column_type_array_cell %}


### PR DESCRIPTION
array cell shouldn't put separator after last element.