### PR TITLE
bugfix: missing parameter in constructor of Manager class

### DIFF
--- a/Translation/ColumnTitleAnnotationTranslationExtractor.php
+++ b/Translation/ColumnTitleAnnotationTranslationExtractor.php
@@ -11,12 +11,18 @@ use JMS\TranslationBundle\Model\FileSource;
 use JMS\TranslationBundle\Model\Message;
 use JMS\TranslationBundle\Model\MessageCatalogue;
 use JMS\TranslationBundle\Translation\Extractor\FileVisitorInterface;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
-class ColumnTitleAnnotationTranslationExtractor implements FileVisitorInterface, \PHPParser_NodeVisitor
+class ColumnTitleAnnotationTranslationExtractor implements FileVisitorInterface, \PHPParser_NodeVisitor, ContainerAwareInterface
 {
     private $annotated;
     private $catalogue;
     private $parsedClassName;
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
 
     public function beforeTraverse(array $nodes) {
         $this->annotated = false;
@@ -56,7 +62,7 @@ class ColumnTitleAnnotationTranslationExtractor implements FileVisitorInterface,
         if ($this->annotated) {
             // Get annotations for the class
             $annotationDriver = new Annotation(new DoctrineAnnotationReader());
-            $manager = new Manager();
+            $manager = new Manager($this->container);
             $manager->addDriver($annotationDriver, -1);
             $metadata = $manager->getMetadata($this->parsedClassName);
 
@@ -73,4 +79,12 @@ class ColumnTitleAnnotationTranslationExtractor implements FileVisitorInterface,
     }
 
     public function visitTwigFile(\SplFileInfo $file, MessageCatalogue $catalogue, \Twig_Node $node) { }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
 }


### PR DESCRIPTION
I had trouble to use `php app/console translation:extract cs -c app` console throwed an error:
```
[Symfony\Component\Debug\Exception\ContextErrorException]                                                                                                                        
Warning: Missing argument 1 for APY\DataGridBundle\Grid\Mapping\Metadata\Manager::__construct(),
called in .../vendor/apy/datagrid-bundle/Translation/ColumnTitleAnnotationTranslationExtractor.php on line 59 and defined 
```

This should fix the issue by passing correct container