### PR TITLE
allow to use manipulateQuery multiple times

### DIFF
--- a/Grid/Source/Source.php
+++ b/Grid/Source/Source.php
@@ -20,7 +20,7 @@ use APY\DataGridBundle\Grid\Row;
 
 abstract class Source implements DriverInterface
 {
-    protected $prepareQueryCallback = null;
+    protected $prepareQueryCallbacks = array();
     protected $prepareRowCallback = null;
     protected $data = null;
     protected $items = array();
@@ -31,8 +31,11 @@ abstract class Source implements DriverInterface
      */
     public function prepareQuery($queryBuilder)
     {
-        if (is_callable($this->prepareQueryCallback)) {
-            call_user_func($this->prepareQueryCallback, $queryBuilder);
+        
+        foreach($this->prepareQueryCallbacks as $prepareQueryCallback) {
+            if (is_callable($prepareQueryCallback)) {
+                call_user_func($prepareQueryCallback, $queryBuilder);
+            }
         }
     }
 
@@ -55,7 +58,7 @@ abstract class Source implements DriverInterface
      */
     public function manipulateQuery($callback = null)
     {
-        $this->prepareQueryCallback = $callback;
+        $this->prepareQueryCallbacks[] = $callback;
 
         return $this;
     }


### PR DESCRIPTION
At the moments next call of manipulateQuery rewrites previous manipulate function. This update allows to call manipulateQuery multiple times