### PR TITLE
Update DataGridExtension.php

### DIFF
--- a/Twig/DataGridExtension.php
+++ b/Twig/DataGridExtension.php
@@ -201,7 +201,7 @@ class DataGridExtension extends \Twig_Extension
      */
     public function getGridCell($column, $row, $grid)
     {
-        $value = $column->renderCell($row->getField($column->getId()), $row, $this->router);
+        $value = $column->renderCell($row->getField($column->getField()), $row, $this->router);
 
         $id = $this->names[$grid->getHash()];
 


### PR DESCRIPTION
Problem occurs when parameter column->id and  coumn->field aren't same. Method sets the wrong value.