### PR TITLE
Fix Symfony2 requirement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
         - php: 7.0
 
 env:
-    - SYMFONY_VERSION=origin/master
+    - SYMFONY_VERSION="2.*"
 
 before_script:
     - curl -s http://getcomposer.org/installer | php

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/symfony": "~2.0",
+        "symfony/symfony": "2.*",
         "twig/twig": ">=1.5.0"
     },
     "require-dev": {


### PR DESCRIPTION
All PR fail since the release of Symfony3, because we use a deprecated service since Symfony 2.6: [Grid/Grid.php#L312](https://github.com/APY/APYDataGridBundle/blob/29c9ea81fd0374e0daebd4f00a120cba66735563/Grid/Grid.php#L312) and [Grid/Column/Column.php#L15](https://github.com/APY/APYDataGridBundle/blob/29c9ea81fd0374e0daebd4f00a120cba66735563/Grid/Column/Column.php#L15).

```>=2``` which says the package should be in version 2.0.0 or above.