### PR TITLE
Replace deprecated \Twig_Extension::initRuntime()

### DIFF
--- a/Twig/DataGridExtension.php
+++ b/Twig/DataGridExtension.php
@@ -22,11 +22,6 @@ class DataGridExtension extends \Twig_Extension
     const DEFAULT_TEMPLATE = 'APYDataGridBundle::blocks.html.twig';
 
     /**
-     * @var \Twig_Environment
-     */
-    protected $environment;
-
-    /**
      * @var \Twig_TemplateInterface[]
      */
     protected $templates = array();
@@ -76,11 +71,6 @@ class DataGridExtension extends \Twig_Extension
         $this->pagerFantaDefs=$def;
     }
 
-    public function initRuntime(\Twig_Environment $environment)
-    {
-        $this->environment = $environment;
-    }
-
     /**
      * @return array
      */
@@ -106,16 +96,16 @@ class DataGridExtension extends \Twig_Extension
     public function getFunctions()
     {
         return array(
-            new \Twig_SimpleFunction('grid', array($this, 'getGrid'), array('is_safe' => array('html'))),
-            new \Twig_SimpleFunction('grid_html', array($this, 'getGridHtml'), array('is_safe' => array('html'))),
+            new \Twig_SimpleFunction('grid', array($this, 'getGrid'), array('is_safe' => array('html'), 'needs_environment' => true)),
+            new \Twig_SimpleFunction('grid_html', array($this, 'getGridHtml'), array('is_safe' => array('html'), 'needs_environment' => true)),
             new \Twig_SimpleFunction('grid_url', array($this, 'getGridUrl'), array('is_safe' => array('html'))),
-            new \Twig_SimpleFunction('grid_filter', array($this, 'getGridFilter'), array('is_safe' => array('html'))),
-            new \Twig_SimpleFunction('grid_column_operator', array($this, 'getGridColumnOperator'), array('is_safe' => array('html'))),
-            new \Twig_SimpleFunction('grid_cell', array($this, 'getGridCell'), array('is_safe' => array('html'))),
-            new \Twig_SimpleFunction('grid_search', array($this, 'getGridSearch'), array('is_safe' => array('html'))),
-            new \Twig_SimpleFunction('grid_pager', array($this, 'getGridPager'), array('is_safe' => array('html'))),
+            new \Twig_SimpleFunction('grid_filter', array($this, 'getGridFilter'), array('is_safe' => array('html'), 'needs_environment' => true)),
+            new \Twig_SimpleFunction('grid_column_operator', array($this, 'getGridColumnOperator'), array('is_safe' => array('html'), 'needs_environment' => true)),
+            new \Twig_SimpleFunction('grid_cell', array($this, 'getGridCell'), array('is_safe' => array('html'), 'needs_environment' => true)),
+            new \Twig_SimpleFunction('grid_search', array($this, 'getGridSearch'), array('is_safe' => array('html'), 'needs_environment' => true)),
+            new \Twig_SimpleFunction('grid_pager', array($this, 'getGridPager'), array('is_safe' => array('html'), 'needs_environment' => true)),
             new \Twig_SimpleFunction('grid_pagerfanta', array($this, 'getPagerfanta'), array('is_safe' => array('html'))),
-            new \Twig_SimpleFunction('grid_*', array($this, 'getGrid_'), array('is_safe' => array('html')))
+            new \Twig_SimpleFunction('grid_*', array($this, 'getGrid_'), array('is_safe' => array('html'), 'needs_environment' => true))
         );
     }
 
@@ -131,104 +121,108 @@ class DataGridExtension extends \Twig_Extension
     /**
      * Render grid block
      *
+     * @param \Twig_Environment $environment
      * @param \APY\DataGridBundle\Grid\Grid $grid
      * @param string $theme
      * @param string $id
      *
      * @return string
      */
-    public function getGrid($grid, $theme = null, $id = '', array $params = array(), $withjs = true)
+    public function getGrid(\Twig_Environment $environment, $grid, $theme = null, $id = '', array $params = array(), $withjs = true)
     {
         $this->initGrid($grid, $theme, $id, $params);
 
         // For export
         $grid->setTemplate($theme);
 
-        return $this->renderBlock('grid', array('grid' => $grid, 'withjs' => $withjs));
+        return $this->renderBlock($environment, 'grid', array('grid' => $grid, 'withjs' => $withjs));
     }
 
     /**
      * Render grid block (html only)
      *
+     * @param \Twig_Environment $environment
      * @param \APY\DataGridBundle\Grid\Grid $grid
      * @param string $theme
      * @param string $id
      *
      * @return string
      */
-    public function getGridHtml($grid, $theme = null, $id = '', array $params = array())
+    public function getGridHtml(\Twig_Environment $environment, $grid, $theme = null, $id = '', array $params = array())
     {
-        return $this->getGrid($grid, $theme, $id, $params, false);
+        return $this->getGrid($environment, $grid, $theme, $id, $params, false);
     }
 
-    public function getGrid_($name, $grid)
+    public function getGrid_(\Twig_Environment $environment, $name, $grid)
     {
-        return $this->renderBlock('grid_' . $name, array('grid' => $grid));
+        return $this->renderBlock($environment, 'grid_' . $name, array('grid' => $grid));
     }
 
-    public function getGridPager($grid)
+    public function getGridPager(\Twig_Environment $environment, $grid)
     {
-        return $this->renderBlock('grid_pager', array('grid' => $grid, 'pagerfanta' => $this->pagerFantaDefs['enable']));
+        return $this->renderBlock($environment, 'grid_pager', array('grid' => $grid, 'pagerfanta' => $this->pagerFantaDefs['enable']));
     }
 
     /**
      * Cell Drawing override
      *
+     * @param \Twig_Environment $environment
      * @param \APY\DataGridBundle\Grid\Column\Column $column
      * @param \APY\DataGridBundle\Grid\Row $row
      * @param \APY\DataGridBundle\Grid\Grid $grid
      *
      * @return string
      */
-    public function getGridCell($column, $row, $grid)
+    public function getGridCell(\Twig_Environment $environment, $column, $row, $grid)
     {
         $value = $column->renderCell($row->getField($column->getId()), $row, $this->router);
 
         $id = $this->names[$grid->getHash()];
 
-        if (($id != '' && ($this->hasBlock($block = 'grid_'.$id.'_column_'.$column->getRenderBlockId().'_cell')
-                        || $this->hasBlock($block = 'grid_'.$id.'_column_'.$column->getType().'_cell')
-                        || $this->hasBlock($block = 'grid_'.$id.'_column_'.$column->getParentType().'_cell')
-                        || $this->hasBlock($block = 'grid_'.$id.'_column_id_'.$column->getRenderBlockId().'_cell')
-                        || $this->hasBlock($block = 'grid_'.$id.'_column_type_'.$column->getType().'_cell')
-                        || $this->hasBlock($block = 'grid_'.$id.'_column_type_'.$column->getParentType().'_cell')))
-         || $this->hasBlock($block = 'grid_column_'.$column->getRenderBlockId().'_cell')
-         || $this->hasBlock($block = 'grid_column_'.$column->getType().'_cell')
-         || $this->hasBlock($block = 'grid_column_'.$column->getParentType().'_cell')
-         || $this->hasBlock($block = 'grid_column_id_'.$column->getRenderBlockId().'_cell')
-         || $this->hasBlock($block = 'grid_column_type_'.$column->getType().'_cell')
-         || $this->hasBlock($block = 'grid_column_type_'.$column->getParentType().'_cell')
+        if (($id != '' && ($this->hasBlock($environment, $block = 'grid_'.$id.'_column_'.$column->getRenderBlockId().'_cell')
+                        || $this->hasBlock($environment, $block = 'grid_'.$id.'_column_'.$column->getType().'_cell')
+                        || $this->hasBlock($environment, $block = 'grid_'.$id.'_column_'.$column->getParentType().'_cell')
+                        || $this->hasBlock($environment, $block = 'grid_'.$id.'_column_id_'.$column->getRenderBlockId().'_cell')
+                        || $this->hasBlock($environment, $block = 'grid_'.$id.'_column_type_'.$column->getType().'_cell')
+                        || $this->hasBlock($environment, $block = 'grid_'.$id.'_column_type_'.$column->getParentType().'_cell')))
+         || $this->hasBlock($environment, $block = 'grid_column_'.$column->getRenderBlockId().'_cell')
+         || $this->hasBlock($environment, $block = 'grid_column_'.$column->getType().'_cell')
+         || $this->hasBlock($environment, $block = 'grid_column_'.$column->getParentType().'_cell')
+         || $this->hasBlock($environment, $block = 'grid_column_id_'.$column->getRenderBlockId().'_cell')
+         || $this->hasBlock($environment, $block = 'grid_column_type_'.$column->getType().'_cell')
+         || $this->hasBlock($environment, $block = 'grid_column_type_'.$column->getParentType().'_cell')
         ) {
-            return $this->renderBlock($block, array('grid' => $grid, 'column' => $column, 'row' => $row, 'value' => $value));
+            return $this->renderBlock($environment, $block, array('grid' => $grid, 'column' => $column, 'row' => $row, 'value' => $value));
         }
 
-        return $this->renderBlock('grid_column_cell', array('grid' => $grid, 'column' => $column, 'row' => $row, 'value' => $value));
+        return $this->renderBlock($environment, 'grid_column_cell', array('grid' => $grid, 'column' => $column, 'row' => $row, 'value' => $value));
     }
 
     /**
      * Filter Drawing override
      *
+     * @param \Twig_Environment $environment
      * @param \APY\DataGridBundle\Grid\Column\Column $column
      * @param \APY\DataGridBundle\Grid\Grid $grid
      *
      * @return string
      */
-    public function getGridFilter($column, $grid, $submitOnChange = true)
+    public function getGridFilter(\Twig_Environment $environment, $column, $grid, $submitOnChange = true)
     {
         $id = $this->names[$grid->getHash()];
 
-        if (($id != '' && ($this->hasBlock($block = 'grid_'.$id.'_column_'.$column->getRenderBlockId().'_filter')
-                        || $this->hasBlock($block = 'grid_'.$id.'_column_id_'.$column->getRenderBlockId().'_filter')
-                        || $this->hasBlock($block = 'grid_'.$id.'_column_type_'.$column->getType().'_filter')
-                        || $this->hasBlock($block = 'grid_'.$id.'_column_type_'.$column->getParentType().'_filter'))
-                        || $this->hasBlock($block = 'grid_'.$id.'_column_filter_type_'.$column->getFilterType()))
-         || $this->hasBlock($block = 'grid_column_'.$column->getRenderBlockId().'_filter')
-         || $this->hasBlock($block = 'grid_column_id_'.$column->getRenderBlockId().'_filter')
-         || $this->hasBlock($block = 'grid_column_type_'.$column->getType().'_filter')
-         || $this->hasBlock($block = 'grid_column_type_'.$column->getParentType().'_filter')
-         || $this->hasBlock($block = 'grid_column_filter_type_'.$column->getFilterType())
+        if (($id != '' && ($this->hasBlock($environment, $block = 'grid_'.$id.'_column_'.$column->getRenderBlockId().'_filter')
+                        || $this->hasBlock($environment, $block = 'grid_'.$id.'_column_id_'.$column->getRenderBlockId().'_filter')
+                        || $this->hasBlock($environment, $block = 'grid_'.$id.'_column_type_'.$column->getType().'_filter')
+                        || $this->hasBlock($environment, $block = 'grid_'.$id.'_column_type_'.$column->getParentType().'_filter'))
+                        || $this->hasBlock($environment, $block = 'grid_'.$id.'_column_filter_type_'.$column->getFilterType()))
+         || $this->hasBlock($environment, $block = 'grid_column_'.$column->getRenderBlockId().'_filter')
+         || $this->hasBlock($environment, $block = 'grid_column_id_'.$column->getRenderBlockId().'_filter')
+         || $this->hasBlock($environment, $block = 'grid_column_type_'.$column->getType().'_filter')
+         || $this->hasBlock($environment, $block = 'grid_column_type_'.$column->getParentType().'_filter')
+         || $this->hasBlock($environment, $block = 'grid_column_filter_type_'.$column->getFilterType())
          ) {
-            return $this->renderBlock($block, array('grid' => $grid, 'column' => $column, 'submitOnChange' => $submitOnChange && $column->isFilterSubmitOnChange()));
+            return $this->renderBlock($environment, $block, array('grid' => $grid, 'column' => $column, 'submitOnChange' => $submitOnChange && $column->isFilterSubmitOnChange()));
         }
 
         return '';
@@ -237,14 +231,15 @@ class DataGridExtension extends \Twig_Extension
     /**
      * Column Operator Drawing override
      *
+     * @param \Twig_Environment $environment
      * @param \APY\DataGridBundle\Grid\Column\Column $column
      * @param \APY\DataGridBundle\Grid\Grid $grid
      *
      * @return string
      */
-    public function getGridColumnOperator($column, $grid, $operator, $submitOnChange = true)
+    public function getGridColumnOperator(\Twig_Environment $environment, $column, $grid, $operator, $submitOnChange = true)
     {
-        return $this->renderBlock('grid_column_operator', array('grid' => $grid, 'column' => $column, 'submitOnChange' => $submitOnChange, 'op' => $operator));
+        return $this->renderBlock($environment, 'grid_column_operator', array('grid' => $grid, 'column' => $column, 'submitOnChange' => $submitOnChange, 'op' => $operator));
     }
 
     /**
@@ -275,11 +270,11 @@ class DataGridExtension extends \Twig_Extension
         }
     }
 
-    public function getGridSearch($grid, $theme = null, $id = '', array $params = array())
+    public function getGridSearch(\Twig_Environment $environment, $grid, $theme = null, $id = '', array $params = array())
     {
         $this->initGrid($grid, $theme, $id, $params);
 
-        return $this->renderBlock('grid_search', array('grid' => $grid));
+        return $this->renderBlock($environment, 'grid_search', array('grid' => $grid));
     }
 
     public function getPagerfanta($grid)
@@ -304,18 +299,19 @@ class DataGridExtension extends \Twig_Extension
     /**
      * Render block
      *
-     * @param string $name
-     * @param array  $parameters
+     * @param \Twig_Environment $environment
+     * @param string            $name
+     * @param array             $parameters
      *
      * @return string
      *
      * @throws \InvalidArgumentException If the block could not be found
      */
-    protected function renderBlock($name, $parameters)
+    protected function renderBlock(\Twig_Environment $environment, $name, $parameters)
     {
-        foreach ($this->getTemplates() as $template) {
+        foreach ($this->getTemplates($environment) as $template) {
             if ($template->hasBlock($name)) {
-                return $template->renderBlock($name, array_merge($this->environment->getGlobals(), $parameters, $this->params));
+                return $template->renderBlock($name, array_merge($environment->getGlobals(), $parameters, $this->params));
             }
         }
 
@@ -325,13 +321,14 @@ class DataGridExtension extends \Twig_Extension
     /**
      * Has block
      *
-     * @param $name string
+     * @param \Twig_Environment $environment
+     * @param string            $name
      *
      * @return boolean
      */
-    protected function hasBlock($name)
+    protected function hasBlock(\Twig_Environment $environment, $name)
     {
-        foreach ($this->getTemplates() as $template) {
+        foreach ($this->getTemplates($environment) as $template) {
             if ($template->hasBlock($name)) {
                 return true;
             }
@@ -343,20 +340,22 @@ class DataGridExtension extends \Twig_Extension
     /**
      * Template Loader
      *
+     * @param \Twig_Environment $environment
+     *
      * @return \Twig_Template[]
      *
      * @throws \Exception
      */
-    protected function getTemplates()
+    protected function getTemplates(\Twig_Environment $environment)
     {
         if (empty($this->templates)) {
             if ($this->theme instanceof \Twig_Template) {
                 $this->templates[] = $this->theme;
-                $this->templates[] = $this->environment->loadTemplate($this->defaultTemplate);
+                $this->templates[] = $environment->loadTemplate($this->defaultTemplate);
             } elseif (is_string($this->theme)) {
-                $this->templates = $this->getTemplatesFromString($this->theme);
+                $this->templates = $this->getTemplatesFromString($environment, $this->theme);
             } elseif ($this->theme === null) {
-                $this->templates = $this->getTemplatesFromString($this->defaultTemplate);
+                $this->templates = $this->getTemplatesFromString($environment, $this->defaultTemplate);
             } else {
                 throw new \Exception('Unable to load template');
             }
@@ -365,11 +364,11 @@ class DataGridExtension extends \Twig_Extension
         return $this->templates;
     }
 
-    protected function getTemplatesFromString($theme)
+    protected function getTemplatesFromString(\Twig_Environment $environment, $theme)
     {
         $this->templates = array();
 
-        $template = $this->environment->loadTemplate($theme);
+        $template = $environment->loadTemplate($theme);
         while ($template != null) {
             $this->templates[] = $template;
             $template = $template->getParent(array());


### PR DESCRIPTION
`\Twig_Extension::initRuntime()` is deprecated since Twig 1.23. This PR aims to replace that method by utilizing the `needs_environment` option in `\Twig_SimpleFunction` instances [as recommended in the documentation](http://twig.sensiolabs.org/doc/deprecated.html#extensions).

I was not sure about BC policy in the extension class. I'd expect that it is rather not intended to be extended in userland, therefore I removed `$environment` and `initRuntime()`. If BC is necessary here, please tell me then I'll rework the PR. We should then also mark `$environment` and `initRuntime()` as deprecated I guess.