### PR TITLE
Implement \Twig_Extension_GlobalsInterface to avoid deprecation notices

### DIFF
--- a/Twig/DataGridExtension.php
+++ b/Twig/DataGridExtension.php
@@ -17,7 +17,7 @@ use Pagerfanta\Pagerfanta;
 use Pagerfanta\Adapter\NullAdapter;
 use Symfony\Component\Routing\RouterInterface;
 
-class DataGridExtension extends \Twig_Extension
+class DataGridExtension extends \Twig_Extension implements \Twig_Extension_GlobalsInterface
 {
     const DEFAULT_TEMPLATE = 'APYDataGridBundle::blocks.html.twig';
 


### PR DESCRIPTION
`\Twig_Extension::getGlobals()` is deprecated since Twig 1.23. To avoid deprecation notices we have to implement `\Twig_Extension_GlobalsInterface` [as suggested in the documentation](http://twig.sensiolabs.org/doc/deprecated.html#extensions).