### PR TITLE
Allow to define a timezone to render a DateTimeColumn

### DIFF
--- a/Grid/Column/DateTimeColumn.php
+++ b/Grid/Column/DateTimeColumn.php
@@ -85,13 +85,13 @@ class DateTimeColumn extends Column
     public function getDisplayedValue($value)
     {
         if (!empty($value)) {
-            $dateTime = $this->getDatetime($value, new \DateTimeZone($this->timezone));
+            $dateTime = $this->getDatetime($value, new \DateTimeZone($this->getTimezone()));
 
             if (isset($this->format)) {
                 $value = $dateTime->format($this->format);
             } else {
                 try {
-                    $transformer = new DateTimeToLocalizedStringTransformer(null, $this->timezone, $this->dateFormat, $this->timeFormat);
+                    $transformer = new DateTimeToLocalizedStringTransformer(null, $this->getTimezone(), $this->dateFormat, $this->timeFormat);
                     $value = $transformer->transform($dateTime);
                 } catch (\Exception $e) {
                     $value = $dateTime->format($this->fallbackFormat);

--- a/Grid/Column/DateTimeColumn.php
+++ b/Grid/Column/DateTimeColumn.php
@@ -24,6 +24,8 @@ class DateTimeColumn extends Column
 
     protected $fallbackFormat = 'Y-m-d H:i:s';
 
+    protected $timezone;
+
     public function __initialize(array $params)
     {
         parent::__initialize($params);
@@ -42,6 +44,7 @@ class DateTimeColumn extends Column
             self::OPERATOR_ISNOTNULL,
         )));
         $this->setDefaultOperator($this->getParam('defaultOperator', self::OPERATOR_EQ));
+        $this->setTimezone($this->getParam('timezone',date_default_timezone_get()));
     }
 
     public function isQueryValid($query)
@@ -82,13 +85,13 @@ class DateTimeColumn extends Column
     public function getDisplayedValue($value)
     {
         if (!empty($value)) {
-            $dateTime = $this->getDatetime($value, new \DateTimeZone(date_default_timezone_get()));
+            $dateTime = $this->getDatetime($value, new \DateTimeZone($this->timezone));
 
             if (isset($this->format)) {
                 $value = $dateTime->format($this->format);
             } else {
                 try {
-                    $transformer = new DateTimeToLocalizedStringTransformer(null, null, $this->dateFormat, $this->timeFormat);
+                    $transformer = new DateTimeToLocalizedStringTransformer(null, $this->timezone, $this->dateFormat, $this->timeFormat);
                     $value = $transformer->transform($dateTime);
                 } catch (\Exception $e) {
                     $value = $dateTime->format($this->fallbackFormat);
@@ -154,6 +157,11 @@ class DateTimeColumn extends Column
     public function getFormat()
     {
         return $this->format;
+    }
+
+    public function setTimezone($timezone)
+    {
+        $this->timezone = $timezone;
     }
 
     public function getType()

--- a/Grid/Column/DateTimeColumn.php
+++ b/Grid/Column/DateTimeColumn.php
@@ -159,10 +159,16 @@ class DateTimeColumn extends Column
         return $this->format;
     }
 
+    public function getTimezone()
+    {
+        return $this->timezone;
+    }
+
     public function setTimezone($timezone)
     {
         $this->timezone = $timezone;
     }
+
 
     public function getType()
     {

--- a/Resources/doc/columns_configuration/types/datetime_column.md
+++ b/Resources/doc/columns_configuration/types/datetime_column.md
@@ -13,7 +13,8 @@ See [Column annotation for properties](../annotations/column_annotation_property
 
 |Attribute|Type|Default value|Possible values|Description|
 |:--:|:--|:--|:--|:--|
-|format|string|||Define this attribute if you want to force the format of the displayed value.<br />(e.g. "Y-m-d H:i:s")|
+|format|string| | |Define this attribute if you want to force the format of the displayed value.<br />(e.g. "Y-m-d H:i:s")|
+|timezone|string|System default timezone| |The timezone to use for rendering.<br />(e.g. "Europe/Paris")|
 
 ## Filter
 #### Valid values


### PR DESCRIPTION
This PR allows to define a timezone instead of relying on the system timezone
@APY/collaborators are you ok with this ?

I will open an issue because I think we should let Twig handle the date formatting