### PR TITLE
Removing default filter in abstract Column Class

### DIFF
--- a/Grid/Column/Column.php
+++ b/Grid/Column/Column.php
@@ -157,7 +157,6 @@ abstract class Column
             self::OPERATOR_ISNULL,
             self::OPERATOR_ISNOTNULL,
         )));
-        $this->setDefaultOperator($this->getParam('defaultOperator', self::OPERATOR_LIKE));
         $this->setSelectMulti($this->getParam('selectMulti', false));
         $this->setSelectExpanded($this->getParam('selectExpanded', false));
         $this->setSearchOnClick($this->getParam('searchOnClick', false));


### PR DESCRIPTION
Line 160 : Setting "like" as default operator in abstract class forcing to display this filter even if it's not appropriate with column type.

Ex : displays "Contains" filter in DateTime column which throw an exception "Catchable Fatal Error: Object of class DateTime could not be converted to string".

Removing it, does not throw issue even if column type is not defined.