### PR TITLE
Add manipulateCountQuery

### DIFF
--- a/Grid/Source/Entity.php
+++ b/Grid/Source/Entity.php
@@ -101,6 +101,11 @@ class Entity extends Source
     protected $tableAlias;
 
     /**
+     * @var null
+     */
+    protected $prepareCountQueryCallback = null;
+
+    /**
      * Legacy way of accessing the default alias (before it became possible to change it)
      * Please use $entity->getTableAlias() now instead of $entity::TABLE_ALIAS
      * @deprecated
@@ -498,6 +503,9 @@ class Entity extends Source
     {
         // Doctrine Bug Workaround: http://www.doctrine-project.org/jira/browse/DDC-1927
         $countQueryBuilder = clone $this->query;
+
+        $this->prepareCountQuery($countQueryBuilder);
+
         foreach ($countQueryBuilder->getRootAliases() as $alias) {
             $countQueryBuilder->addSelect($alias);
         }
@@ -680,6 +688,27 @@ class Entity extends Source
                 }
             }
         }
+    }
+
+    /**
+     * @param QueryBuilder $countQueryBuilder
+     */
+    public function prepareCountQuery(QueryBuilder $countQueryBuilder)
+    {
+        if (is_callable($this->prepareCountQueryCallback)) {
+            call_user_func($this->prepareCountQueryCallback, $countQueryBuilder);
+        }
+    }
+
+    /**
+     * @param callable $callback
+     * @return $this
+     */
+    public function manipulateCountQuery($callback = null)
+    {
+        $this->prepareCountQueryCallback = $callback;
+
+        return $this;
     }
 
     public function delete(array $ids)

--- a/Grid/Source/Source.php
+++ b/Grid/Source/Source.php
@@ -60,6 +60,7 @@ abstract class Source implements DriverInterface
         return $this;
     }
 
+
     /**
      * @param \Closure $callback
      */

--- a/Resources/doc/grid_configuration/manipulate_count_query.md
+++ b/Resources/doc/grid_configuration/manipulate_count_query.md
@@ -1,0 +1,45 @@
+Manipulating the count query builder
+============================
+
+The grid requires the total number of results (COUNT (...)). The grid clones the source QueryBuilder and wraps it with a COUNT DISTINCT clause.
+If you use a lot of aggregation in the source queryBuilder you may encounter performance problems.
+You can manipulate the query before it is processed to remove useless fields for the COUNT clause.
+
+## 1. Using a callback
+
+```php
+<?php
+...
+$source->manipulateCountQuery($callback);
+
+$grid->setSource($source);
+...
+```
+
+### Method Source::manipulateCountQuery parameters
+
+|parameter|Type|Default value|Description|
+|:--:|:--|:--|:--|:--|
+|callback|[\Closure](http://php.net/manual/en/functions.anonymous.php) or [callable](http://php.net/manual/en/language.types.callable.php)|null|Callback to manipulate the query. Null means no callback.|
+
+### Callback parameters
+
+|parameter|Type|Description|
+|:--:|:--|:--|:--|:--|
+|queryBuilder|instance of QueryBuilder|The QueryBuilder instance before its execution (clone of the source QueryBuilder)|
+
+### Examples
+
+```php
+<?php
+...
+$source->manipulateCountQuery(
+    function ($queryBuilder)
+    {
+        $queryBuilder->resetDQLPart('select');
+    }
+);
+
+$grid->setSource($source);
+...
+```

--- a/Resources/doc/summary.md
+++ b/Resources/doc/summary.md
@@ -65,6 +65,7 @@ SUMMARY
 	1. [Manipulate rows data](grid_configuration/manipulate_rows_data.md)
 	1. [Manipulate column render cell](grid_configuration/manipulate_column_render_cell.md)
 	1. [Manipulate the source query](grid_configuration/manipulate_query.md)
+	1. [Manipulate the count query (source Entity only)](grid_configuration/manipulate_count_query.md)
 	1. [Manipulate columns](grid_configuration/manipulate_column.md)
 	1. [Manipulate row action rendering](grid_configuration/manipulate_row_action_rendering.md)
 	1. [Hide or show columns](grid_configuration/hide_show_columns.md)


### PR DESCRIPTION
I have a grid with a lot of aggregation, the query to get the grid page is fast (~80ms in db) beacause of the LIMIT clause but the count query is very slow (~400ms) because of this aggregations.
This PR allows to manipulate the count querybuilder, to remove useless field for example.
