### PR TITLE
Fix join queries

### DIFF
--- a/Grid/Source/Entity.php
+++ b/Grid/Source/Entity.php
@@ -789,6 +789,10 @@ class Entity extends Source
     protected function checkIfQueryHasFetchJoin(QueryBuilder $qb)
     {
         $join = $qb->getDqlPart('join');
+        if (empty($join)) {
+            return false;
+        }
+
         foreach ($join[$this->getTableAlias()] as $join) {
             if ($join->getJoinType() === Join::INNER_JOIN) {
                 return true;


### PR DESCRIPTION
## Bug description:

When trying to show in grid results of query which was using Doctrine's fetch join there was problem with pagination and numbers of results showed in grid.

Error was caused because in code SQL querry LIMIT clause was used - with fetch join of one to many relationship LIMIT cannot be used because number of SQL rows is bigger than number of grid rows (Doctrine is hydrating it to main table's entity object). 

Because of that pagination was not working and not all results was showed, because of LIMIT clause in SQL querry.