### PR TITLE
Composer lowest dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,15 +8,18 @@ php:
     - 7.0
 
 matrix:
+    include:
+        - php: 5.3
+          env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
     allow_failures:
         - php: 7.0
 
 env:
     - SYMFONY_VERSION="2.*"
 
-before_script:
-    - curl -s http://getcomposer.org/installer | php
-    - php composer.phar install
+install:
+  - travis_retry composer self-update
+  - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction
 
 script:
-    - phpunit
+    - vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,25 +1,31 @@
 language: php
 
 php:
-    - 5.3
-    - 5.4
-    - 5.5
-    - 5.6
-    - 7.0
+  - 5.3
+  - 5.4
+  - 5.5
+  - 5.6
+  - 7.0
 
 matrix:
-    include:
-        - php: 5.3
-          env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
-    allow_failures:
-        - php: 7.0
+  include:
+    - php: 5.3
+      env: 'COMPOSER_FLAGS="--prefer-stable --prefer-lowest"'
+    - php: 5.6
+      env: |
+        SYMFONY_VERSION=2.7.*
+    - php: 5.6
+      env: |
+        SYMFONY_VERSION=2.8.*
+  allow_failures:
+    - php: 7.0
 
-env:
-    - SYMFONY_VERSION="2.*"
+before_install:
+  - sh -c 'if [ "${SYMFONY_VERSION}" != "" ]; then composer require --no-update symfony/symfony=${SYMFONY_VERSION}; fi;';
 
 install:
   - travis_retry composer self-update
   - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction
 
 script:
-    - vendor/bin/phpunit
+  - vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,6 @@ matrix:
     - php: 5.6
       env: |
         SYMFONY_VERSION=2.8.*
-  allow_failures:
-    - php: 7.0
 
 before_install:
   - sh -c 'if [ "${SYMFONY_VERSION}" != "" ]; then composer require --no-update symfony/symfony=${SYMFONY_VERSION}; fi;';

--- a/Grid/Type/GridType.php
+++ b/Grid/Type/GridType.php
@@ -56,14 +56,30 @@ class GridType extends AbstractType
             'sortable'         => true,
         ));
 
-        $resolver->setAllowedTypes('source', array('null', 'APY\DataGridBundle\Grid\Source\Source'));
-        $resolver->setAllowedTypes('group_by', array('null', 'string', 'array'));
-        $resolver->setAllowedTypes('route_parameters', 'array');
-        $resolver->setAllowedTypes('persistence', 'bool');
-        $resolver->setAllowedTypes('filterable', 'bool');
-        $resolver->setAllowedTypes('sortable', 'bool');
+        $allowedTypes = array(
+            'source' => array('null', 'APY\DataGridBundle\Grid\Source\Source'),
+            'group_by' => array('null', 'string', 'array'),
+            'route_parameters' => 'array',
+            'persistence' => 'bool',
+            'filterable' => 'bool',
+            'sortable' => 'bool',
+        );
+        $allowedValues = array(
+            'order' => array('asc', 'desc'),
+        );
+        if (method_exists($resolver, 'setDefault')) {
+            // Symfony 2.6.0 and up
+            foreach ($allowedTypes as $option => $types) {
+                $resolver->setAllowedTypes($option, $types);
+            }
 
-        $resolver->setAllowedValues('order', array('asc', 'desc'));
+            foreach ($allowedValues as $option => $values) {
+                $resolver->setAllowedValues($option, $values);
+            }
+        } else {
+            $resolver->setAllowedTypes($allowedTypes);
+            $resolver->setAllowedValues($allowedValues);
+        }
     }
 
     /**

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": ">=5.3.2",
         "symfony/symfony": "~2.3",
-        "twig/twig": ">=1.5.0"
+        "twig/twig": ">=1.23.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.1.1"


### PR DESCRIPTION
Hi there,

Here are some Travis and dependency fixes.
This PR includes:
- Testing lowest composer dependencies and related fixes (twig 1.23 or higher required and a fix for the OptionsResolver)
- Testing specific symfony versions (2.8 and 2.7)
- No more errors allowed on PHP 7

Let me know what you think.

Cheers,
Warnar