### PR TITLE
Fix DeleteMassAction

### DIFF
--- a/Grid/Grid.php
+++ b/Grid/Grid.php
@@ -612,9 +612,9 @@ class Grid implements GridInterface
                     $this->page = 0;
                     $this->limit = 0;
                 }
-                
+
                 $this->prepare();
-                
+
                 if($actionAllKeys == true){
                     foreach($this->rows as $row){
                         $actionKeys[]=$row->getPrimaryFieldValue();
@@ -2073,9 +2073,10 @@ class Grid implements GridInterface
     /**
      * Default delete action
      *
-     * @param $ids
+     * @param array $ids
+     * @param boolean $actionAllKeys
      */
-    public function deleteAction($ids, $actionAllKeys)
+    public function deleteAction(array $ids, $actionAllKeys)
     {
         $this->source->delete($ids, $actionAllKeys);
     }

--- a/Grid/Source/Document.php
+++ b/Grid/Source/Document.php
@@ -501,21 +501,25 @@ class Document extends Source
         }
     }
 
-    public function delete(array $ids)
+    public function delete(array $ids, $actionAllKeys)
     {
-        $repository = $this->getRepository();
+        if (true === $actionAllKeys) {
+            $this->query->delete($this->documentName, $this->tableAlias)->getQuery()->execute();
+        } else {
+            $repository = $this->getRepository();
 
-        foreach ($ids as $id) {
-            $object = $repository->find($id);
+            foreach ($ids as $id) {
+                $object = $repository->find($id);
 
-            if (!$object) {
-                throw new \Exception(sprintf('No %s found for id %s', $this->documentName, $id));
+                if (!$object) {
+                    throw new \Exception(sprintf('No %s found for id %s', $this->documentName, $id));
+                }
+
+                $this->manager->remove($object);
             }
 
-            $this->manager->remove($object);
+            $this->manager->flush();
         }
-
-        $this->manager->flush();
     }
 
     public function getRepository()

--- a/Grid/Source/Entity.php
+++ b/Grid/Source/Entity.php
@@ -381,7 +381,7 @@ class Entity extends Source
                         $fieldName = "LOWER($fieldName)";
                         $bindIndexPlaceholder = "LOWER($bindIndexPlaceholder)";
                     }
-                    
+
                     $q = $this->query->expr()->$operator($fieldName, $bindIndexPlaceholder);
 
                     if ($filter->getOperator() == Column::OPERATOR_NLIKE || $filter->getOperator() == Column::OPERATOR_NSLIKE) {
@@ -711,21 +711,25 @@ class Entity extends Source
         return $this;
     }
 
-    public function delete(array $ids)
+    public function delete(array $ids, $actionAllKeys)
     {
-        $repository = $this->getRepository();
+        if (true === $actionAllKeys) {
+            $this->query->delete($this->entityName, $this->tableAlias)->getQuery()->execute();
+        } else {
+            $repository = $this->getRepository();
 
-        foreach ($ids as $id) {
-            $object = $repository->find($id);
+            foreach ($ids as $id) {
+                $object = $repository->find($id);
 
-            if (!$object) {
-                throw new \Exception(sprintf('No %s found for id %s', $this->entityName, $id));
+                if (!$object) {
+                    throw new \Exception(sprintf('No %s found for id %s', $this->entityName, $id));
+                }
+
+                $this->manager->remove($object);
             }
 
-            $this->manager->remove($object);
+            $this->manager->flush();
         }
-
-        $this->manager->flush();
     }
 
     public function getRepository()

--- a/Grid/Source/Source.php
+++ b/Grid/Source/Source.php
@@ -134,9 +134,9 @@ abstract class Source implements DriverInterface
      *
      * @abstract
      * @param array $ids
-     * @return void
+     * @param boolean $actionAllKeys
      */
-    abstract public function delete(array $ids);
+    abstract public function delete(array $ids, $actionAllKeys);
 
     /**
      * Use data instead of fetching the source

--- a/Grid/Source/Vector.php
+++ b/Grid/Source/Vector.php
@@ -107,7 +107,7 @@ class Vector extends Source
                         } else {
                             $fieldTypes['datetime'] = 1;
                         }
-                        
+
                     } elseif (strlen($fieldValue) >= 3 && strtotime($fieldValue) !== false) {
                         $dt = new \DateTime($fieldValue);
                         if ($dt->format('His') === '000000') {
@@ -247,7 +247,7 @@ class Vector extends Source
         }
     }
 
-    public function delete(array $ids)
+    public function delete(array $ids, $actionAllKeys)
     {
     }
 

--- a/Resources/views/blocks.html.twig
+++ b/Resources/views/blocks.html.twig
@@ -250,7 +250,7 @@
 {% endblock grid_column_actions_cell %}
 {# ------------------------------------------------ grid_column_massaction_cell --------------------------------------------- #}
 {% block grid_column_massaction_cell %}
-    <input type="checkbox" class="action" value="1" name="{{ grid.hash }}[{{ column.id }}][{{ row.primaryFieldValue }}]"/>
+    <input type="checkbox" class="action" value="1" name="{{ grid.hash }}[{{ column.id }}][{{ row.primaryFieldValue }}]" onclick="{{ grid.hash }}_updateVisible(this.checked);" />
 {% endblock grid_column_massaction_cell %}
 {# ------------------------------------------------ grid_column_type_boolean_cell --------------------------------------------- #}
 {% block grid_column_boolean_cell %}
@@ -404,6 +404,7 @@
 {{ grid_scripts_enter_page(grid) }}
 {{ grid_scripts_results_per_page(grid) }}
 {{ grid_scripts_mark_visible(grid) }}
+{{ grid_scripts_update_visible(grid) }}
 {{ grid_scripts_mark_all(grid) }}
 {{ grid_scripts_switch_operator(grid) }}
 {{ grid_scripts_submit_form(grid) }}
@@ -490,6 +491,7 @@ function {{ grid.hash }}_markVisible(select)
     for (var i=0; i < form.elements.length; i++ ) {
         if (form.elements[i].type == 'checkbox') {
             form.elements[i].checked = select;
+            form.elements[i].disabled = false;
 
             if (form.elements[i].checked){
                counter++;
@@ -510,6 +512,34 @@ function {{ grid.hash }}_markVisible(select)
 }
 {% endblock grid_scripts_mark_visible %}
 
+{% block grid_scripts_update_visible %}
+    function {{ grid.hash }}_updateVisible(select)
+    {
+    var form = document.getElementById('{{ grid.hash }}');
+
+    var counter = 0;
+
+    for (var i=0; i < form.elements.length; i++ ) {
+    if (form.elements[i].type == 'checkbox') {
+    if (form.elements[i].checked){
+    counter++;
+    }
+    }
+    }
+
+    {% if grid.isFilterSectionVisible %}
+        counter--;
+    {% endif %}
+
+    var selected = document.getElementById('{{ grid.hash }}_mass_action_selected');
+    selected.innerHTML = counter > 0 ? '{{ 'Selected _s_ rows'|trans }}'.replace('_s_', counter) : '';
+
+    document.getElementById('{{ grid.hash }}_mass_action_all').value = '0';
+
+    return false;
+    }
+{% endblock grid_scripts_update_visible %}
+
 {% block grid_scripts_mark_all %}
 function {{ grid.hash }}_markAll(select)
 {
@@ -518,6 +548,7 @@ function {{ grid.hash }}_markAll(select)
     for (var i=0; i < form.elements.length; i++ ) {
         if (form.elements[i].type == 'checkbox') {
             form.elements[i].checked = select;
+            form.elements[i].disabled = select;
         }
     }
 


### PR DESCRIPTION
Default mass action DeleteMassAction is not working when all lines are selected : nothing is deleted with Entity source and Document source.

The problem is that the callback of MassAction defined by DeleleMassAction, "static::deleteAction", defined in Grid.php, is calling "delete" function of grid source, but the abstract "Source" class "delete" function as only one argument wich is selected ids. This function does not support $actionAllKeys value.

Furthermore, when all is selected, unchecking a row checkbox as no effect. I just disabled checboxes when Select All is clicked.