### PR TITLE
Fixed condition for the join column

### DIFF
--- a/Grid/Source/Entity.php
+++ b/Grid/Source/Entity.php
@@ -13,6 +13,7 @@
 namespace APY\DataGridBundle\Grid\Source;
 
 use APY\DataGridBundle\Grid\Column\Column;
+use APY\DataGridBundle\Grid\Column\JoinColumn;
 use APY\DataGridBundle\Grid\Rows;
 use APY\DataGridBundle\Grid\Row;
 use Doctrine\ORM\NoResultException;
@@ -350,7 +351,7 @@ class Entity extends Source
             }
 
             if ($column->isSorted()) {
-                if ($column->getType() === 'join') {
+                if ($column instanceof JoinColumn) {
                     $this->query->resetDQLPart('orderBy');
                     foreach($column->getJoinColumns() as $columnName) {
                         $this->query->addOrderBy($this->getFieldName($columnsById[$columnName]), $column->getOrder());
@@ -373,7 +374,7 @@ class Entity extends Source
                 foreach ($filters as $filter) {
                     $operator = $this->normalizeOperator($filter->getOperator());
 
-                    $columnForFilter = ($column->getType() !== 'join') ? $column : $columnsById[$filter->getColumnName()];
+                    $columnForFilter = (!$column instanceof JoinColumn) ? $column : $columnsById[$filter->getColumnName()];
 
                     $fieldName = $this->getFieldName($columnForFilter, false);
                     $bindIndexPlaceholder = "?$bindIndex";


### PR DESCRIPTION
When I create a custom column that extends `JoinColumn`, my column doesn't work because the type for my column is equal to *my_custom_column* and not  *join*.