### PR TITLE
Custom column values are now applied if filterType="select" and selectFrom="source" or selectFrom="query"

### DIFF
--- a/Grid/Source/Document.php
+++ b/Grid/Source/Document.php
@@ -495,6 +495,7 @@ class Document extends Source
                     $column->setSelectFrom('source');
                     $this->populateSelectFilters($columns, true);
                 } else {
+                    $values = $this->prepareColumnValues($column, $values);
                     $column->setValues($values);
                 }
             }

--- a/Grid/Source/Entity.php
+++ b/Grid/Source/Entity.php
@@ -685,6 +685,7 @@ class Entity extends Source
                         natcasesort($values);
                     }
 
+                    $values = $this->prepareColumnValues($column, $values);
                     $column->setValues($values);
                 }
             }

--- a/Grid/Source/Source.php
+++ b/Grid/Source/Source.php
@@ -463,7 +463,7 @@ abstract class Source implements DriverInterface
 
     public function populateSelectFiltersFromData($columns, $loop = false)
     {
-        /* @var $column Column */
+        /* @var $column Column\Column */
         foreach ($columns as $column) {
             $selectFrom = $column->getSelectFrom();
 
@@ -529,6 +529,7 @@ abstract class Source implements DriverInterface
                         natcasesort($values);
                     }
 
+                    $values = $this->prepareColumnValues($column, $values);
                     $column->setValues(array_unique($values));
                 }
             }
@@ -568,5 +569,16 @@ abstract class Source implements DriverInterface
         $noaccentStr = preg_replace('#&([A-za-z])(?:acute|cedil|circ|grave|orn|ring|slash|th|tilde|uml);#', '\1', $entStr);
 
         return preg_replace('#&([A-za-z]{2})(?:lig);#', '\1', $noaccentStr);
+    }
+
+    protected function prepareColumnValues(Column\Column $column, $values)
+    {
+        $existingValues = $column->getValues();
+        if (!empty($existingValues)) {
+            $intersect = array_intersect_key($existingValues, $values);
+            $values = array_replace($values, $intersect);
+        }
+
+        return $values;
     }
 }


### PR DESCRIPTION
Hello.

As per the documentation: https://github.com/APY/APYDataGridBundle/blob/master/Resources/doc/columns_configuration/filters/select_filter.md

> Note: With the values attributes, if type1 is found, the grid displays the value Type 1. This feature works with other type of filters.

As far as I understand it works only if selectFrom="values". If you set selectFrom="source" or "query" - "type1" will be displayed, but not "Type 1".
This tiny commit should fix the things up.
