### PR TITLE
PHP-CS-Fixer integration

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,8 @@
         "twig/twig": ">=1.23.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4.1.1"
+        "phpunit/phpunit": "~4.1.1",
+        "friendsofphp/php-cs-fixer": "1.11.*"
     },
     "suggest": {
         "ext-intl": "Translate the grid",

--- a/php_cs.dist
+++ b/php_cs.dist
@@ -1,0 +1,91 @@
+<?php
+
+$finder = Symfony\CS\Finder\DefaultFinder::create()
+    ->in([__DIR__])
+    ->exclude('vendor')
+    ->name('*.php');
+
+return Symfony\CS\Config\Config::create()
+    ->finder($finder)
+    ->setUsingCache(true)
+    ->fixers([
+        // 'psr0',                                // [PSR-0]   Classes must be in a path that matches their namespace, be at least one namespace deep, and the class name should match the file name.
+
+        'encoding',                               // [PSR-1]   PHP code MUST use only UTF-8 without BOM (remove BOM).
+        'short_tag',                              // [PSR-1]   PHP code must use the long <?php tags or the short-echo <?= tags; it must not use the other tag variations.
+
+        'braces',                                 // [PSR-2]   The body of each structure MUST be enclosed by braces. Braces should be properly placed. Body of braces should be properly indented.
+        'elseif',                                 // [PSR-2]   The keyword elseif should be used instead of else if so that all control keywords looks like single words.
+        'eof_ending',                             // [PSR-2]   A file must always end with a single empty line feed.
+        'function_call_space',                    // [PSR-2]   When making a method or function call, there MUST NOT be a space between the method or function name and the opening parenthesis.
+        'function_declaration',                   // [PSR-2]   Spaces should be properly placed in a function declaration.
+        'indentation',                            // [PSR-2]   Code MUST use an indent of 4 spaces, and MUST NOT use tabs for indenting.
+        'line_after_namespace',                   // [PSR-2]   There MUST be one blank line after the namespace declaration.
+        'linefeed',                               // [PSR-2]   All PHP files must use the Unix LF (linefeed) line ending.
+        'lowercase_constants',                    // [PSR-2]   The PHP constants true, false, and null MUST be in lower case.
+        'lowercase_keywords',                     // [PSR-2]   PHP keywords MUST be in lower case.
+        'method_argument_space',                  // [PSR-2]   In method arguments and method call, there MUST NOT be a space before each comma and there MUST be one space after each comma.
+        'multiple_use',                           // [PSR-2]   There MUST be one use keyword per declaration.
+        'parenthesis',                            // [PSR-2]   There MUST NOT be a space after the opening parenthesis. There MUST NOT be a space before the closing parenthesis.
+        'php_closing_tag',                        // [PSR-2]   The closing tag MUST be omitted from files containing only PHP.
+        'single_line_after_imports',              // [PSR-2]   Each namespace use MUST go on its own line and there MUST be one blank line after the use statements block.
+        'trailing_spaces',                        // [PSR-2]   Remove trailing whitespace at the end of non-blank lines.
+        'visibility',                             // [PSR-2]   Visibility MUST be declared on all properties and methods; abstract and final MUST be declared before the visibility; static MUST be declared after the visibility.
+
+        'array_element_white_space_after_comma',
+        'blankline_after_open_tag',               // [symfony] Ensure there is no code on the same line as the PHP open tag and it is followed by a blankline.
+        'double_arrow_multiline_whitespaces',     // [symfony] Operator => should not be arounded by multi-line whitespaces.
+        'duplicate_semicolon',                    // [symfony] Remove duplicated semicolons.
+        'empty_return',                           // [symfony] A return statement wishing to return nothing should be simply "return".
+        'extra_empty_lines',                      // [symfony] Removes extra empty lines
+        'function_typehint_space',
+        'include',                                // [symfony] Include and file path should be divided with a single space. File path should not be placed under brackets.
+        'join_function',                          // [symfony] Implode function should be used instead of join function.
+        'list_commas',                            // [symfony] Remove trailing commas in list function calls.
+        'multiline_array_trailing_comma',         // [symfony] PHP multi-line arrays should have a trailing comma.
+        'namespace_no_leading_whitespace',        // [symfony] The namespace declaration line shouldn't contain leading whitespace.
+        // 'new_with_braces',                     // [symfony] All instances created with new keyword must be followed by braces.
+        'no_blank_lines_after_class_opening',     // [symfony] There should be no empty lines after class opening brace.
+        'no_empty_lines_after_phpdocs',           // [symfony] There should not be blank lines between docblock and the documented element.
+        'object_operator',                        // [symfony] There should not be space before or after object T_OBJECT_OPERATOR.
+        'operators_spaces',                       // [symfony] Binary operators should be arounded by at least one space.
+        'phpdoc_indent',                          // [symfony] Docblocks should have the same indentation as the documented subject.
+        'phpdoc_inline_tag',
+        'phpdoc_no_access',                       // [symfony] @access annotations should be omitted from phpdocs.
+        'phpdoc_no_empty_return',                 // [symfony] @return void and @return null annotations should be omitted from phpdocs.
+        'phpdoc_no_package',                      // [symfony] @package and @subpackage annotations should be omitted from phpdocs.
+        'phpdoc_params',                          // [symfony] All items of the @param, @throws, @return, @var, and @type phpdoc tags must be aligned vertically.
+        'phpdoc_scalar',                          // [symfony] Scalar types should always be written in the same form. "int", not "integer"; "bool", not "boolean"; "float", not "real" or "double".
+        'phpdoc_separation',                      // [symfony] Annotations in phpdocs should be grouped together so that annotations of the same type immediately follow each other, and annotations of a different type are separated by a single blank line.
+        'phpdoc_short_description',               // [symfony] Phpdocs short descriptions should end in either a full stop, exclamation mark, or question mark.
+        'phpdoc_to_comment',                      // [symfony] Docblocks should only be used on structural elements.
+        'phpdoc_trim',                            // [symfony] Phpdocs should start and end with content, excluding the very first and last line of the docblocks.
+        'phpdoc_type_to_var',                     // [symfony] @type should always be written as @var.
+        'phpdoc_var_without_name',                // [symfony] @var and @type annotations should not contain the variable name.
+        'pre_increment',                         // [symfony] Pre incrementation/decrementation should be used if possible.
+        'remove_leading_slash_use',               // [symfony] Remove leading slashes in use clauses.
+        'remove_lines_between_uses',              // [symfony] Removes line breaks between use statements.
+        'return',                                 // [symfony] An empty line feed should precede a return statement.
+        'self_accessor',                          // [symfony] Inside a classy element "self" should be preferred to the class name itself.
+        //'single_array_no_trailing_comma',         // [symfony] PHP single-line arrays should not have trailing comma.
+        'single_blank_line_before_namespace',     // [symfony] There should be exactly one blank line before a namespace declaration.
+        'single_quote',                           // [symfony] Convert double quotes to single quotes for simple strings.
+        'spaces_before_semicolon',                // [symfony] Single-line whitespace before closing semicolon are prohibited.
+        'spaces_cast',                            // [symfony] A single space should be between cast and variable.
+        'standardize_not_equal',                  // [symfony] Replace all <> with !=.
+        'ternary_spaces',                         // [symfony] Standardize spaces around ternary operator.
+        'trim_array_spaces',                      // [symfony] Arrays should be formatted like function/method arguments, without leading or trailing single line space.
+        // 'unalign_double_arrow',                // [symfony] Unalign double arrow symbols.
+        'unalign_equals',                         // [symfony] Unalign equals symbols.
+        'unneeded_control_parentheses',
+        'unary_operators_spaces',                 // [symfony] Unary operators should be placed adjacent to their operands.
+        'unused_use',                          // [symfony] Unused use statements must be removed.
+        'whitespacy_lines',                       // [symfony] Remove trailing whitespace at the end of blank lines.
+
+        'concat_with_spaces',
+        'align_double_arrow',
+        'multiline_spaces_before_semicolon',
+        'ordered_use',
+        'phpdoc_order',
+        'short_array_syntax',
+    ]);


### PR DESCRIPTION
As https://github.com/APY/APYDataGridBundle/pull/898 is generated from php-cs-fixer, I've integrated it (only dev) in composer: if you like to integrate with this bundle, just accept this PR also. 
Moreover if you want me to write a little guide into readme for this tool usage, please let me know.