### PR TITLE
Missing parameters in router->generate

### DIFF
--- a/Grid/Grid.php
+++ b/Grid/Grid.php
@@ -336,17 +336,17 @@ class Grid implements GridInterface
 
         $this->setPersistence($config->isPersisted());
 
-        // Route
-        if (null != $config->getRoute()) {
-            $this->setRouteUrl($this->router->generate($config->getRoute()));
-        }
-
         // Route parameters
         $routeParameters = $config->getRouteParameters();
         if (!empty($routeParameters)) {
             foreach ($routeParameters as $parameter => $value) {
                 $this->setRouteParameter($parameter, $value);
             }
+        }
+
+        // Route
+        if (null != $config->getRoute()) {
+            $this->setRouteUrl($this->router->generate($config->getRoute(), $routeParameters));
         }
 
         // Columns


### PR DESCRIPTION
Hi, 

I found a little bug when building a grid (with GridType pattern) with a custom route and  mandatory parameters.

In `Grid:Initialize` method, the `route_parameters` option was not used with the `$router->generate` function, generating an `MissingMandatoryParametersException`.
