### PR TITLE
Fix for issue #931 Fixed The Paginator does not support ScalarResults

### DIFF
--- a/Grid/Source/Entity.php
+++ b/Grid/Source/Entity.php
@@ -514,7 +514,7 @@ class Entity extends Source
         foreach ($this->hints as $hintKey => $hintValue) {
             $query->setHint($hintKey, $hintValue);
         }
-        $items = new Paginator($query, $hasJoin);
+        $items = $query->getResult();
 
         $repository = $this->manager->getRepository($this->entityName);
 


### PR DESCRIPTION
Fix for issue. https://github.com/APY/APYDataGridBundle/issues/931