### PR TITLE
Disable the Output walkers of Entity with joins (Fixes #931)

### DIFF
--- a/Grid/Source/Entity.php
+++ b/Grid/Source/Entity.php
@@ -515,6 +515,7 @@ class Entity extends Source
             $query->setHint($hintKey, $hintValue);
         }
         $items = new Paginator($query, $hasJoin);
+        $items->setUseOutputWalkers(false);
 
         $repository = $this->manager->getRepository($this->entityName);
 


### PR DESCRIPTION
Fix for issue #931 
There is another pull request #939 , but it will revert the functionality added by commit #828 