### PR TITLE
Add ActionsColumn::__construct missing docblock 

### DIFF
--- a/Grid/Column/ActionsColumn.php
+++ b/Grid/Column/ActionsColumn.php
@@ -16,6 +16,13 @@ class ActionsColumn extends Column
 {
     protected $rowActions;
 
+     /**
+     * ActionsColumn constructor.
+     *
+     * @param string $column     Identifier of the column
+     * @param string $title      Title of the column
+     * @param array  $rowActions Array of rowAction
+     */
     public function __construct($column, $title, array $rowActions = [])
     {
         $this->rowActions = $rowActions;


### PR DESCRIPTION
Add missing docblock for `ActionsColumn::__construct`  to prevent IDE warning "Expected array, got string" when create a new `ActionsColumn` instance.