### PR TITLE
Fix ajax grid filtering - value not urlencoded

### DIFF
--- a/Resources/views/blocks_js.jquery.html.twig
+++ b/Resources/views/blocks_js.jquery.html.twig
@@ -31,10 +31,10 @@ function {{ grid.hash }}_submitForm(event, form)
                     if ($(this).attr('multiple') == 'multiple') {
                         for(var i= 0; i < value.length; i++)
                         {
-                            data += '&' + name + '=' + value[i];
+                            data += '&' + name + '=' + encodeURIComponent(value[i]);
                         }
                     } else {
-                        data += '&' + name + '=' + value;
+                        data += '&' + name + '=' + encodeURIComponent(value);
                     }
                 } else {
                     data += '&' + name + '=';


### PR DESCRIPTION
When submitting an ajax filter with a value like "AT&T" the filter is interpreted wrong because it is not passed as encoded string to the request and gets cut off.