### PR TITLE
fix error in displaying a page beyond the last one with a custom QB

### DIFF
--- a/Grid/Source/Entity.php
+++ b/Grid/Source/Entity.php
@@ -352,10 +352,10 @@ class Entity extends Source
      */
     protected function getQueryBuilder()
     {
-        //If a custom QB has been provided, use that
+        //If a custom QB has been provided, use a copy of that one
         //Otherwise create our own basic one
         if ($this->queryBuilder instanceof QueryBuilder) {
-            $qb = $this->queryBuilder;
+            $qb = clone $this->queryBuilder;
         } else {
             $qb = $this->manager->createQueryBuilder($this->class);
             $qb->from($this->class, $this->getTableAlias());


### PR DESCRIPTION
`Entity::execute()` needs to support being called multiple times as `Grid::prepare()` calls itself if the current page is empty to reset to page 1