### PR TITLE
Symfony 4 : fix service definition and response rendering

### DIFF
--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -20,7 +20,7 @@
             </call>
         </service>
 
-        <service id="grid" class="%grid.class%" shared="false">
+        <service id="grid" class="%grid.class%" shared="false" public="true">
             <argument type="service" id="service_container" />
             <call method="setLimits">
                 <argument>%apy_data_grid.limits%</argument>
@@ -50,7 +50,7 @@
             <argument type="service" id="annotation_reader" />
         </service>
 
-        <service id="grid.mapping.manager" class="APY\DataGridBundle\Grid\Mapping\Metadata\Manager" shared="false">
+        <service id="grid.mapping.manager" class="APY\DataGridBundle\Grid\Mapping\Metadata\Manager" shared="false" public="true">
             <argument type="service" id="form.factory"/>
             <call method="addDriver">
                 <argument type="service" id="grid.metadata.driver.annotation" />
@@ -58,5 +58,5 @@
             </call>
         </service>
     </services>
-    
+
 </container>


### PR DESCRIPTION
As Symfony 4 register services as private by default, we have to specify grid and grid.mapping.manager services as a public to be able to use them.