### PR TITLE
Removed the "2" from Symfony2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-Datagrid for Symfony2 inspired by Zfdatagrid and Magento Grid.  
+Datagrid for Symfony inspired by Zfdatagrid and Magento Grid.  
 This bundle was initiated by Stanislav Turza (Sorien).
 
 [![Build Status](https://secure.travis-ci.org/APY/APYDataGridBundle.png?branch=master)](http://travis-ci.org/APY/APYDataGridBundle) 


### PR DESCRIPTION
Calling it Symfony2 discourages newcomers from adopting packages that work just fine with newer versions.