### PR TITLE
Updated `branch-alias` for next minor release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "3.2-dev"
+            "dev-master": "3.3-dev"
         }
     },
     "provide": {


### PR DESCRIPTION
Should solve:
```
root@0238daca8508:/srv/www/seduo# composer require apy/datagrid-bundle "^3.2"
Do not run Composer as root/super user! See https://getcomposer.org/root for details
./composer.json has been updated
Loading composer repositories with package information
Updating dependencies (including require-dev)
Your requirements could not be resolved to an installable set of packages.

  Problem 1
    - The requested package apy/datagrid-bundle ^3.2 is satisfiable by apy/datagrid-bundle[3.2.x-dev] but these conflict with your requirements or minimum-stability.

Installation failed, reverting ./composer.json to its original content.
```
Our composer configuration for `minimum-stability` is `stable` (which is by default).

Please release patch version 3.2.1 after merge (I hope I understand semver correctly).