### PR TITLE
DateTime and Date columns : add input filter format option

### DIFF
--- a/Grid/Column/DateColumn.php
+++ b/Grid/Column/DateColumn.php
@@ -20,6 +20,8 @@ class DateColumn extends DateTimeColumn
 
     protected $fallbackFormat = 'Y-m-d';
 
+    protected $fallbackInputFormat = 'Y-m-d';
+
     public function getFilters($source)
     {
         $parentFilters = parent::getFilters($source);

--- a/Grid/Column/DateTimeColumn.php
+++ b/Grid/Column/DateTimeColumn.php
@@ -24,6 +24,10 @@ class DateTimeColumn extends Column
 
     protected $fallbackFormat = 'Y-m-d H:i:s';
 
+    protected $inputFormat;
+
+    protected $fallbackInputFormat = 'Y-m-d H:i:s';
+
     protected $timezone;
 
     public function __initialize(array $params)
@@ -31,6 +35,7 @@ class DateTimeColumn extends Column
         parent::__initialize($params);
 
         $this->setFormat($this->getParam('format'));
+        $this->setInputFormat($this->getParam('inputFormat', $this->fallbackInputFormat));
         $this->setOperators($this->getParam('operators', [
             self::OPERATOR_EQ,
             self::OPERATOR_NEQ,
@@ -56,7 +61,7 @@ class DateTimeColumn extends Column
 
     protected function isDateTime($query)
     {
-        return strtotime($query) !== false;
+        return false !== \DateTime::createFromFormat($this->inputFormat, $query);
     }
 
     public function getFilters($source)
@@ -65,7 +70,7 @@ class DateTimeColumn extends Column
 
         $filters = [];
         foreach ($parentFilters as $filter) {
-            $filters[] = ($filter->getValue() === null) ? $filter : $filter->setValue(new \DateTime($filter->getValue()));
+            $filters[] = ($filter->getValue() === null) ? $filter : $filter->setValue(\DateTime::createFromFormat($this->inputFormat, $filter->getValue()));
         }
 
         return $filters;
@@ -158,6 +163,18 @@ class DateTimeColumn extends Column
     public function getFormat()
     {
         return $this->format;
+    }
+
+    public function setInputFormat($inputFormat)
+    {
+        $this->inputFormat = $inputFormat;
+
+        return $this;
+    }
+
+    public function getInputFormat()
+    {
+        return $this->inputFormat;
     }
 
     public function getTimezone()

--- a/Resources/doc/columns_configuration/types/date_column.md
+++ b/Resources/doc/columns_configuration/types/date_column.md
@@ -1,7 +1,7 @@
 Date Column
 ===========
 
-The Date Column extends the [DateTime Column](datetime_column.md) and the default fallback format is `Y-m-d`.
+The Date Column extends the [DateTime Column](datetime_column.md) and the default fallback format and filter input format are `Y-m-d`.
 
 With this column, the time part of a datetime value is ignored when you filter the column.  
 So, if you filter the column with the value `2012-04-26` or `2012-04-26 12:23:45` and with the operator `=`, the query will be `date >= '2012-04-26 0:00:00' AND date <= '2012-04-26 23:59:59'`.

--- a/Resources/doc/columns_configuration/types/datetime_column.md
+++ b/Resources/doc/columns_configuration/types/datetime_column.md
@@ -15,6 +15,9 @@ See [Column annotation for properties](../annotations/column_annotation_property
 |:--:|:--|:--|:--|:--|
 |format|string| | |Define this attribute if you want to force the format of the displayed value.<br />(e.g. "Y-m-d H:i:s")|
 |timezone|string|System default timezone| |The timezone to use for rendering.<br />(e.g. "Europe/Paris")|
+|inputFormat|string|"Y-m-d H:i:s"| |Define this attribute if you want to force the format of the filtered value.<br />(e.g. "Y-m-d H:i:s")|
+
+**Note**: If you want to filter using date input (and not datetime input), you should use the [Date Column](date_column.md) type instead and configure the display format to render the time (e.g. "Y-m-d H:i:s").
 
 ## Filter
 #### Valid values


### PR DESCRIPTION
This PR add an inputFormat option in DateTime and Date columns in order to filter using values with non english format.
Fixes #143, #305 and #468 issues