### PR TITLE
Fixed YAML in example configuration

### DIFF
--- a/Resources/doc/configuration.md
+++ b/Resources/doc/configuration.md
@@ -14,7 +14,7 @@ apy_data_grid:
     actions_columns_separator: "<br />"
     pagerfanta:
         enable: false
-        view_class: "Pagerfanta\View\DefaultView"
+        view_class: "Pagerfanta\\View\\DefaultView"
         options:
             prev_message: "«"
             next_message: "»"


### PR DESCRIPTION
Hello,

This PR fixes a small typo: in YAML, backslashes should be escaped.
Copy-pasting example configuration would crash the application with Symfony >= 3 (and a deprecation warning with Symfony 2.8).

![image](https://user-images.githubusercontent.com/919405/65886733-257f9680-e39d-11e9-93a4-0b87ba06c78e.png)

As far I know, it does not break BC (since escaping \\ is part of YAML specification).
