### PR TITLE
composer memory limit

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ before_script:
 
 install:
   - travis_retry composer self-update
-  - travis_retry composer update ${COMPOSER_FLAGS} --no-interaction
+  - COMPOSER_MEMORY_LIMIT=-1 travis_retry composer update ${COMPOSER_FLAGS} --no-interaction
   - curl -s http://getcomposer.org/installer | php
   - php composer.phar install --dev --no-interaction
 


### PR DESCRIPTION
This PR adds `COMPOSER_MEMORY_LIMIT=-1 ` to the command `composer update` executed in **Travis**. 

it resolves issue #1050. As you can [see here](https://travis-ci.org/github/APY/APYDataGridBundle/builds/669610077) the build works now