### PR TITLE
Fix Tests namespace

### DIFF
--- a/Tests/Action/MassActionTest.php
+++ b/Tests/Action/MassActionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace APY\DataGridBundle\Tests\Grid\Action;
+namespace APY\DataGridBundle\Tests\Action;
 
 use APY\DataGridBundle\Grid\Action\MassAction;
 use PHPUnit\Framework\TestCase;

--- a/Tests/Grid/ColumnsTest.php
+++ b/Tests/Grid/ColumnsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace APY\DataGridBundle\Grid\Tests;
+namespace APY\DataGridBundle\Tests\Grid;
 
 use APY\DataGridBundle\Grid\Column\Column;
 use APY\DataGridBundle\Grid\Columns;

--- a/Tests/Grid/FilterTest.php
+++ b/Tests/Grid/FilterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace APY\DataGridBundle\Grid\Tests;
+namespace APY\DataGridBundle\Tests\Grid;
 
 use APY\DataGridBundle\Grid\Filter;
 use PHPUnit\Framework\TestCase;

--- a/Tests/Grid/GridBuilderTest.php
+++ b/Tests/Grid/GridBuilderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace APY\DataGridBundle\Grid\Tests;
+namespace APY\DataGridBundle\Tests\Grid;
 
 use APY\DataGridBundle\Grid\Column\Column;
 use APY\DataGridBundle\Grid\Exception\InvalidArgumentException;

--- a/Tests/Grid/GridConfigBuilderTest.php
+++ b/Tests/Grid/GridConfigBuilderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace APY\DataGridBundle\Grid\Tests;
+namespace APY\DataGridBundle\Tests\Grid;
 
 use APY\DataGridBundle\Grid\Action\RowActionInterface;
 use APY\DataGridBundle\Grid\GridConfigBuilder;

--- a/Tests/Grid/GridManagerTest.php
+++ b/Tests/Grid/GridManagerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace APY\DataGridBundle\Grid\Tests;
+namespace APY\DataGridBundle\Tests\Grid;
 
 use APY\DataGridBundle\Grid\Grid;
 use APY\DataGridBundle\Grid\GridManager;

--- a/Tests/Grid/GridTest.php
+++ b/Tests/Grid/GridTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace APY\DataGridBundle\Grid\Tests;
+namespace APY\DataGridBundle\Tests\Grid;
 
 use APY\DataGridBundle\Grid\Action\MassAction;
 use APY\DataGridBundle\Grid\Action\RowAction;

--- a/Tests/Grid/Mapping/ColumnTest.php
+++ b/Tests/Grid/Mapping/ColumnTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace APY\DataGridBundle\Grid\Tests\Mapping;
+namespace APY\DataGridBundle\Tests\Grid\Mapping;
 
 use APY\DataGridBundle\Grid\Mapping\Column;
 use PHPUnit\Framework\TestCase;

--- a/Tests/Grid/Mapping/Metadata/DriverHeapTest.php
+++ b/Tests/Grid/Mapping/Metadata/DriverHeapTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace APY\DataGridBundle\Grid\Tests\Mapping\Metadata;
+namespace APY\DataGridBundle\Tests\Grid\Mapping\Metadata;
 
 use APY\DataGridBundle\Grid\Mapping\Metadata\DriverHeap;
 use PHPUnit\Framework\TestCase;

--- a/Tests/Grid/Mapping/Metadata/ManagerTest.php
+++ b/Tests/Grid/Mapping/Metadata/ManagerTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace APY\DataGridBundle\Grid\Tests\Mapping\Metadata;
+namespace APY\DataGridBundle\Tests\Grid\Mapping\Metadata;
 
 use APY\DataGridBundle\Grid\Mapping\Driver\DriverInterface;
 use APY\DataGridBundle\Grid\Mapping\Metadata\DriverHeap;

--- a/Tests/Grid/Mapping/Metadata/MetadataTest.php
+++ b/Tests/Grid/Mapping/Metadata/MetadataTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace APY\DataGridBundle\Grid\Tests\Mapping\Metadata;
+namespace APY\DataGridBundle\Tests\Grid\Mapping\Metadata;
 
 use APY\DataGridBundle\Grid\Column\Column;
 use APY\DataGridBundle\Grid\Columns;

--- a/Tests/Grid/Mapping/SourceTest.php
+++ b/Tests/Grid/Mapping/SourceTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace APY\DataGridBundle\Grid\Tests\Mapping;
+namespace APY\DataGridBundle\Tests\Grid\Mapping;
 
 use APY\DataGridBundle\Grid\Mapping\Source;
 use PHPUnit\Framework\TestCase;

--- a/Tests/Grid/RowTest.php
+++ b/Tests/Grid/RowTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace APY\DataGridBundle\Grid\Tests;
+namespace APY\DataGridBundle\Tests\Grid;
 
 use APY\DataGridBundle\Grid\Row;
 use Doctrine\ORM\EntityRepository;

--- a/Tests/Grid/RowsTest.php
+++ b/Tests/Grid/RowsTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace APY\DataGridBundle\Grid\Tests;
+namespace APY\DataGridBundle\Tests\Grid;
 
 use APY\DataGridBundle\Grid\Row;
 use APY\DataGridBundle\Grid\Rows;

--- a/Tests/Grid/Source/DocumentTest.php
+++ b/Tests/Grid/Source/DocumentTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace APY\DataGridBundle\Grid\Tests\Source;
+namespace APY\DataGridBundle\Tests\Grid\Source;
 
 use APY\DataGridBundle\Grid\Column\Column;
 use APY\DataGridBundle\Grid\Columns;

--- a/Tests/Grid/Source/VectorTest.php
+++ b/Tests/Grid/Source/VectorTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace APY\DataGridBundle\Grid\Tests\Source;
+namespace APY\DataGridBundle\Tests\Grid\Source;
 
 use APY\DataGridBundle\Grid\Column\Column;
 use APY\DataGridBundle\Grid\Column\UntypedColumn;


### PR DESCRIPTION
To remove deprecation notice on ```composer dumpautoload --optimize``` execution

### Before:
```
$ composer dumpautoload --optimize
Generating optimized autoload files
Deprecation Notice: Class Guzzle\Tests\Common\Cache\NullCacheAdapterTest located in ./vendor/guzzle/guzzle/tests/Guzzle/Tests/Cache/NullCacheAdapterTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Guzzle\Tests\Common\AbstractHasAdapterTest located in ./vendor/guzzle/guzzle/tests/Guzzle/Tests/Common/AbstractHasDispatcherTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Guzzle\Tests\Service\ServiceBuilderTest located in ./vendor/guzzle/guzzle/tests/Guzzle/Tests/Service/Builder/ServiceBuilderTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Guzzle\Tests\Service\Command\AliasFactoryTest located in ./vendor/guzzle/guzzle/tests/Guzzle/Tests/Service/Command/Factory/AliasFactoryTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Guzzle\Tests\Service\Command\ConcreteClassFactoryTest located in ./vendor/guzzle/guzzle/tests/Guzzle/Tests/Service/Command/Factory/ConcreteClassFactoryTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Guzzle\Tests\Service\Command\CompositeFactoryTest located in ./vendor/guzzle/guzzle/tests/Guzzle/Tests/Service/Command/Factory/CompositeFactoryTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Guzzle\Tests\Service\Command\MapFactoryTest located in ./vendor/guzzle/guzzle/tests/Guzzle/Tests/Service/Command/Factory/MapFactoryTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Guzzle\Tests\Service\Command\ServiceDescriptionFactoryTest located in ./vendor/guzzle/guzzle/tests/Guzzle/Tests/Service/Command/Factory/ServiceDescriptionFactoryTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Guzzle\Tests\Service\Command\VisitorFlyweightTest located in ./vendor/guzzle/guzzle/tests/Guzzle/Tests/Service/Command/LocationVisitor/VisitorFlyweightTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Guzzle\Tests\Plugin\Redirect\RedirectPluginTest located in ./vendor/guzzle/guzzle/tests/Guzzle/Tests/Http/RedirectPluginTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Guzzle\Tests\Http\CommaAggregatorTest located in ./vendor/guzzle/guzzle/tests/Guzzle/Tests/Http/QueryAggregator/CommaAggregatorTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Guzzle\Tests\Http\PhpAggregatorTest located in ./vendor/guzzle/guzzle/tests/Guzzle/Tests/Http/QueryAggregator/PhpAggregatorTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Guzzle\Tests\Http\DuplicateAggregatorTest located in ./vendor/guzzle/guzzle/tests/Guzzle/Tests/Http/QueryAggregator/DuplicateAggregatorTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Guzzle\Tests\Plugin\Redirect\StaticClientTest located in ./vendor/guzzle/guzzle/tests/Guzzle/Tests/Http/StaticClientTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Guzzle\Tests\Message\ResponseTest located in ./vendor/guzzle/guzzle/tests/Guzzle/Tests/Http/Message/ResponseTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Guzzle\Tests\Http\Message\HttpRequestFactoryTest located in ./vendor/guzzle/guzzle/tests/Guzzle/Tests/Http/Message/RequestFactoryTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Guzzle\Tests\Message\HeaderComparisonTest located in ./vendor/guzzle/guzzle/tests/Guzzle/Tests/Http/Message/HeaderComparisonTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Guzzle\Tests\Parsers\UriTemplate\PeclUriTemplateTest located in ./vendor/guzzle/guzzle/tests/Guzzle/Tests/Parser/UriTemplate/PeclUriTemplateTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Guzzle\Tests\Parsers\UriTemplate\AbstractUriTemplateTest located in ./vendor/guzzle/guzzle/tests/Guzzle/Tests/Parser/UriTemplate/AbstractUriTemplateTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Guzzle\Tests\Parsers\UriTemplate\UriTemplateTest located in ./vendor/guzzle/guzzle/tests/Guzzle/Tests/Parser/UriTemplate/UriTemplateTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class APY\DataGridBundle\Grid\Tests\GridConfigBuilderTest located in ./Tests/Grid/GridConfigBuilderTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class APY\DataGridBundle\Grid\Tests\RowTest located in ./Tests/Grid/RowTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class APY\DataGridBundle\Grid\Tests\GridBuilderTest located in ./Tests/Grid/GridBuilderTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class APY\DataGridBundle\Grid\Tests\RowsTest located in ./Tests/Grid/RowsTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class APY\DataGridBundle\Grid\Tests\GridTest located in ./Tests/Grid/GridTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class APY\DataGridBundle\Grid\Tests\Mapping\ColumnTest located in ./Tests/Grid/Mapping/ColumnTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class APY\DataGridBundle\Grid\Tests\Mapping\Metadata\DriverHeapTest located in ./Tests/Grid/Mapping/Metadata/DriverHeapTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class APY\DataGridBundle\Grid\Tests\Mapping\Metadata\MetadataTest located in ./Tests/Grid/Mapping/Metadata/MetadataTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class APY\DataGridBundle\Grid\Tests\Mapping\Metadata\ManagerTest located in ./Tests/Grid/Mapping/Metadata/ManagerTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class APY\DataGridBundle\Grid\Tests\Mapping\SourceTest located in ./Tests/Grid/Mapping/SourceTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class APY\DataGridBundle\Grid\Tests\GridManagerTest located in ./Tests/Grid/GridManagerTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class APY\DataGridBundle\Grid\Tests\ColumnsTest located in ./Tests/Grid/ColumnsTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class APY\DataGridBundle\Grid\Tests\Source\VectorTest located in ./Tests/Grid/Source/VectorTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class APY\DataGridBundle\Grid\Tests\Source\VectorObj located in ./Tests/Grid/Source/VectorTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class APY\DataGridBundle\Grid\Tests\Source\DocumentTest located in ./Tests/Grid/Source/DocumentTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class APY\DataGridBundle\Grid\Tests\Source\DocumentEntity located in ./Tests/Grid/Source/DocumentTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class APY\DataGridBundle\Grid\Tests\FilterTest located in ./Tests/Grid/FilterTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class APY\DataGridBundle\Tests\Grid\Action\MassActionTest located in ./Tests/Action/MassActionTest.php does not comply with psr-4 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Generated optimized autoload files containing 4476 classes
```

### After:
```
$ composer dumpautoload --optimize
Generating optimized autoload files
Deprecation Notice: Class Guzzle\Tests\Common\Cache\NullCacheAdapterTest located in ./vendor/guzzle/guzzle/tests/Guzzle/Tests/Cache/NullCacheAdapterTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Guzzle\Tests\Common\AbstractHasAdapterTest located in ./vendor/guzzle/guzzle/tests/Guzzle/Tests/Common/AbstractHasDispatcherTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Guzzle\Tests\Service\ServiceBuilderTest located in ./vendor/guzzle/guzzle/tests/Guzzle/Tests/Service/Builder/ServiceBuilderTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Guzzle\Tests\Service\Command\AliasFactoryTest located in ./vendor/guzzle/guzzle/tests/Guzzle/Tests/Service/Command/Factory/AliasFactoryTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Guzzle\Tests\Service\Command\ConcreteClassFactoryTest located in ./vendor/guzzle/guzzle/tests/Guzzle/Tests/Service/Command/Factory/ConcreteClassFactoryTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Guzzle\Tests\Service\Command\CompositeFactoryTest located in ./vendor/guzzle/guzzle/tests/Guzzle/Tests/Service/Command/Factory/CompositeFactoryTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Guzzle\Tests\Service\Command\MapFactoryTest located in ./vendor/guzzle/guzzle/tests/Guzzle/Tests/Service/Command/Factory/MapFactoryTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Guzzle\Tests\Service\Command\ServiceDescriptionFactoryTest located in ./vendor/guzzle/guzzle/tests/Guzzle/Tests/Service/Command/Factory/ServiceDescriptionFactoryTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Guzzle\Tests\Service\Command\VisitorFlyweightTest located in ./vendor/guzzle/guzzle/tests/Guzzle/Tests/Service/Command/LocationVisitor/VisitorFlyweightTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Guzzle\Tests\Plugin\Redirect\RedirectPluginTest located in ./vendor/guzzle/guzzle/tests/Guzzle/Tests/Http/RedirectPluginTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Guzzle\Tests\Http\CommaAggregatorTest located in ./vendor/guzzle/guzzle/tests/Guzzle/Tests/Http/QueryAggregator/CommaAggregatorTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Guzzle\Tests\Http\PhpAggregatorTest located in ./vendor/guzzle/guzzle/tests/Guzzle/Tests/Http/QueryAggregator/PhpAggregatorTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Guzzle\Tests\Http\DuplicateAggregatorTest located in ./vendor/guzzle/guzzle/tests/Guzzle/Tests/Http/QueryAggregator/DuplicateAggregatorTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Guzzle\Tests\Plugin\Redirect\StaticClientTest located in ./vendor/guzzle/guzzle/tests/Guzzle/Tests/Http/StaticClientTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Guzzle\Tests\Message\ResponseTest located in ./vendor/guzzle/guzzle/tests/Guzzle/Tests/Http/Message/ResponseTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Guzzle\Tests\Http\Message\HttpRequestFactoryTest located in ./vendor/guzzle/guzzle/tests/Guzzle/Tests/Http/Message/RequestFactoryTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Guzzle\Tests\Message\HeaderComparisonTest located in ./vendor/guzzle/guzzle/tests/Guzzle/Tests/Http/Message/HeaderComparisonTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Guzzle\Tests\Parsers\UriTemplate\PeclUriTemplateTest located in ./vendor/guzzle/guzzle/tests/Guzzle/Tests/Parser/UriTemplate/PeclUriTemplateTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Guzzle\Tests\Parsers\UriTemplate\AbstractUriTemplateTest located in ./vendor/guzzle/guzzle/tests/Guzzle/Tests/Parser/UriTemplate/AbstractUriTemplateTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Deprecation Notice: Class Guzzle\Tests\Parsers\UriTemplate\UriTemplateTest located in ./vendor/guzzle/guzzle/tests/Guzzle/Tests/Parser/UriTemplate/UriTemplateTest.php does not comply with psr-0 autoloading standard. It will not autoload anymore in Composer v2.0. in phar:///home/socloz/.composer/vendor/bin/composer/src/Composer/Autoload/ClassMapGenerator.php:201
Generated optimized autoload files containing 4436 classes

```