### PR TITLE
Update namespace in GridBuilderTest.php

### DIFF
--- a/Tests/Grid/GridBuilderTest.php
+++ b/Tests/Grid/GridBuilderTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace APY\DataGridBundle\Grid\Tests;
+namespace APY\DataGridBundle\Tests\Grid;
 
 use APY\DataGridBundle\Grid\Column\Column;
 use APY\DataGridBundle\Grid\Exception\InvalidArgumentException;


### PR DESCRIPTION
fix composer message "./vendor/apy/datagrid-bundle/Tests/Grid/GridBuilderTest.php does not comply with psr-4 autoloading standard. Skipping."