### PR TITLE
Check if value is numeric before abs()

### DIFF
--- a/Grid/Source/Source.php
+++ b/Grid/Source/Source.php
@@ -315,12 +315,12 @@ abstract class Source implements DriverInterface
                         // Test
                         switch ($operator) {
                             case Column::OPERATOR_EQ:
-                                if ($dataIsNumeric) {
+                                if ($dataIsNumeric && is_numeric($value)) {
                                     $found = abs($fieldValue - $value) < 0.00001;
                                     break;
                                 }
                             case Column::OPERATOR_NEQ:
-                                if ($dataIsNumeric) {
+                                if ($dataIsNumeric && is_numeric($value)) {
                                     $found = abs($fieldValue - $value) > 0.00001;
                                     break;
                                 }


### PR DESCRIPTION
I use 3.0.2 version in my project and I upgraded PHP version from 5.6 to 7.2 and $value sometimes by default appear as "-" string instead of a number.