### PR TITLE
fix after the method was removed from the ORM

### DIFF
--- a/Grid/Source/Entity.php
+++ b/Grid/Source/Entity.php
@@ -17,6 +17,7 @@ use APY\DataGridBundle\Grid\Column\Column;
 use APY\DataGridBundle\Grid\Column\JoinColumn;
 use APY\DataGridBundle\Grid\Row;
 use APY\DataGridBundle\Grid\Rows;
+use Doctrine\ORM\Internal\SQLResultCasing;
 use Doctrine\ORM\NoResultException;
 use Doctrine\ORM\Query;
 use Doctrine\ORM\QueryBuilder;
@@ -28,6 +29,8 @@ use Symfony\Component\HttpKernel\Kernel;
 
 class Entity extends Source
 {
+    use SQLResultCasing;
+
     const DOT_DQL_ALIAS_PH = '__dot__';
     const COLON_DQL_ALIAS_PH = '__col__';
 
@@ -609,7 +612,7 @@ class Entity extends Source
             $platform = $countQuery->getEntityManager()->getConnection()->getDatabasePlatform(); // law of demeter win
 
             $rsm = new ResultSetMapping();
-            $rsm->addScalarResult($platform->getSQLResultCasing('dctrn_count'), 'count');
+            $rsm->addScalarResult($this->getSQLResultCasing($platform,'dctrn_count'), 'count');
 
             $countQuery->setHint(Query::HINT_CUSTOM_OUTPUT_WALKER, 'Doctrine\ORM\Tools\Pagination\CountOutputWalker');
             $countQuery->setResultSetMapping($rsm);

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,7 @@
         "phpunit/phpunit": "^9.5",
         "friendsofphp/php-cs-fixer": "^2.0",
         "php-coveralls/php-coveralls": "^2.0",
-        "doctrine/orm": "~2.4,>=2.4.5",
+        "doctrine/orm": "~2.10,>=2.10.0",
         "doctrine/mongodb-odm": "^2.2",
         "rector/rector": "^0.12.13",
         "dg/bypass-finals": "^1.3"


### PR DESCRIPTION
See : https://github.com/APY/APYDataGridBundle/issues/1073

Thanks @marcelostrappini for reporting it and @FredDut for the fix

I've added some small changes ton ensure that `doctrine/orm` has the good minimum version