### PR TITLE
Use phpoffice/phpspreadsheet for Excel Export

### DIFF
--- a/Grid/Export/PHPExcel2003Export.php
+++ b/Grid/Export/PHPExcel2003Export.php
@@ -12,12 +12,14 @@
 
 namespace APY\DataGridBundle\Grid\Export;
 
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
+
 /**
  * PHPExcel_Excel 2003 Export (.xlsx).
  */
 class PHPExcel2003Export extends PHPExcel2007Export
 {
-    protected function getWriter()
+    protected function getWriter(): Xlsx
     {
         $writer = parent::getWriter();
         $writer->setOffice2003Compatibility(true);

--- a/Grid/Export/PHPExcel2007Export.php
+++ b/Grid/Export/PHPExcel2007Export.php
@@ -12,20 +12,19 @@
 
 namespace APY\DataGridBundle\Grid\Export;
 
+use PhpOffice\PhpSpreadsheet\Writer\Xlsx;
+
 /**
  * PHPExcel 2007 Export.
  */
-class PHPExcel2007Export extends PHPExcel5Export
+class PHPExcel2007Export extends PHPExcelExport
 {
     protected $fileExtension = 'xlsx';
 
     protected $mimeType = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet';
 
-    protected function getWriter()
+    protected function getWriter(): Xlsx
     {
-        $writer = new \PHPExcel_Writer_Excel2007($this->objPHPExcel);
-        $writer->setPreCalculateFormulas(false);
-
-        return $writer;
+        return new Xlsx($this->objPHPExcel);
     }
 }

--- a/Grid/Export/PHPExcel5Export.php
+++ b/Grid/Export/PHPExcel5Export.php
@@ -12,55 +12,21 @@
 
 namespace APY\DataGridBundle\Grid\Export;
 
-use APY\DataGridBundle\Grid\Grid;
+use PhpOffice\PhpSpreadsheet\Writer\IWriter;
+use PhpOffice\PhpSpreadsheet\Writer\Xls;
 
 /**
  * PHPExcel 5 Export (97-2003) (.xls)
  * 52 columns maximum.
  */
-class PHPExcel5Export extends Export
+class PHPExcel5Export extends PHPExcelExport
 {
     protected $fileExtension = 'xls';
 
     protected $mimeType = 'application/vnd.ms-excel';
 
-    public $objPHPExcel;
-
-    public function __construct($tilte, $fileName = 'export', $params = [], $charset = 'UTF-8')
+    protected function getWriter(): IWriter
     {
-        $this->objPHPExcel = new \PHPExcel();
-
-        parent::__construct($tilte, $fileName, $params, $charset);
-    }
-
-    public function computeData(Grid $grid)
-    {
-        $data = $this->getFlatGridData($grid);
-
-        $row = 1;
-        foreach ($data as $line) {
-            $column = 'A';
-            foreach ($line as $cell) {
-                $this->objPHPExcel->getActiveSheet()->SetCellValue($column . $row, $cell);
-
-                ++$column;
-            }
-            ++$row;
-        }
-
-        $objWriter = $this->getWriter();
-
-        ob_start();
-
-        $objWriter->save('php://output');
-
-        $this->content = ob_get_contents();
-
-        ob_end_clean();
-    }
-
-    protected function getWriter()
-    {
-        return new \PHPExcel_Writer_Excel5($this->objPHPExcel);
+        return new Xls($this->objPHPExcel);
     }
 }

--- a/Grid/Export/PHPExcelExport.php
+++ b/Grid/Export/PHPExcelExport.php
@@ -1,0 +1,69 @@
+<?php
+
+/*
+ * This file is part of the DataGridBundle.
+ *
+ * (c) Abhoryo <abhoryo@free.fr>
+ * (c) Stanislav Turza
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace APY\DataGridBundle\Grid\Export;
+
+use APY\DataGridBundle\Grid\Grid;
+
+use PhpOffice\PhpSpreadsheet\Spreadsheet;
+use PhpOffice\PhpSpreadsheet\Writer\IWriter;
+use PhpOffice\PhpSpreadsheet\Writer\Xls;
+
+/**
+ * Excel
+ */
+class PHPExcelExport extends Export
+{
+    protected $fileExtension = 'xls';
+
+    protected $mimeType = 'application/vnd.ms-excel';
+
+    protected Spreadsheet $objPHPExcel;
+
+    public function __construct($title, $fileName = 'export', $params = [], $charset = 'UTF-8', $role = null)
+    {
+        parent::__construct($title, $fileName, $params, $charset, $role);
+        $this->objPHPExcel = new Spreadsheet;
+    }
+
+    public function computeData(Grid $grid): void
+    {
+
+        $data = $this->getFlatGridData($grid);
+
+        $row = 1;
+        foreach ($data as $line) {
+            $column = 'A';
+            foreach ($line as $cell) {
+                $this->objPHPExcel->getActiveSheet()->SetCellValue($column . $row, $cell);
+
+                ++$column;
+            }
+            ++$row;
+        }
+
+        $objWriter = $this->getWriter();
+
+        ob_start();
+
+        $objWriter->save('php://output');
+
+        $this->content = ob_get_contents();
+
+        ob_end_clean();
+    }
+
+    protected function getWriter(): IWriter
+    {
+        return new Xls($this->objPHPExcel);
+    }
+}

--- a/Grid/Export/PHPExcelHTMLExport.php
+++ b/Grid/Export/PHPExcelHTMLExport.php
@@ -1,29 +1,17 @@
 <?php
 
-/*
- * This file is part of the DataGridBundle.
- *
- * (c) Abhoryo <abhoryo@free.fr>
- * (c) Stanislav Turza
- *
- * For the full copyright and license information, please view the LICENSE
- * file that was distributed with this source code.
- */
-
 namespace APY\DataGridBundle\Grid\Export;
 
-/**
- * PHPExcel HTML Export.
- */
-class PHPExcelHTMLExport extends PHPExcel5Export
+use PhpOffice\PhpSpreadsheet\Writer\Html;
+
+class PHPExcelHTMLExport extends PHPExcelExport
 {
-    protected $fileExtension = 'html';
+    protected $fileExtension = "html";
+    protected $mimeType = "text/html";
 
-    protected $mimeType = 'text/html';
-
-    protected function getWriter()
+    protected function getWriter(): Html
     {
-        $writer = new \PHPExcel_Writer_HTML($this->objPHPExcel);
+        $writer = new Html($this->objPHPExcel);
         $writer->setPreCalculateFormulas(false);
 
         return $writer;

--- a/Grid/Export/PHPExcelMDFExport.php
+++ b/Grid/Export/PHPExcelMDFExport.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace APY\DataGridBundle\Grid\Export;
+
+
+use PhpOffice\PhpSpreadsheet\Writer\Pdf\Mpdf;
+
+class PHPExcelMDFExport extends PHPExcelPDFExport
+{
+    protected function getWriter(): Mpdf
+    {
+        $writer = new Mpdf($this->objPHPExcel);
+        $writer->setPreCalculateFormulas(false);
+
+        return $writer;
+    }
+}

--- a/Grid/Export/PHPExcelMPDFExport.php
+++ b/Grid/Export/PHPExcelMPDFExport.php
@@ -5,7 +5,7 @@ namespace APY\DataGridBundle\Grid\Export;
 
 use PhpOffice\PhpSpreadsheet\Writer\Pdf\Mpdf;
 
-class PHPExcelMDFExport extends PHPExcelPDFExport
+class PHPExcelMPDFExport extends PHPExcelPDFExport
 {
     protected function getWriter(): Mpdf
     {

--- a/Grid/Export/PHPExcelPDFExport.php
+++ b/Grid/Export/PHPExcelPDFExport.php
@@ -9,29 +9,11 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
-
 namespace APY\DataGridBundle\Grid\Export;
 
-/**
- * PHPExcel PDF Export.
- */
-class PHPExcelPDFExport extends PHPExcel5Export
+abstract class PHPExcelPDFExport extends PHPExcelExport
 {
     protected $fileExtension = 'pdf';
 
     protected $mimeType = 'application/pdf';
-
-    protected function getWriter()
-    {
-        //$this->objPHPExcel->getActiveSheet()->getPageSetup()->setOrientation(\PHPExcel_Worksheet_PageSetup::ORIENTATION_LANDSCAPE);
-        //$this->objPHPExcel->getActiveSheet()->getPageSetup()->setPaperSize(\PHPExcel_Worksheet_PageSetup::PAPERSIZE_A4);
-        //$this->objPHPExcel->getActiveSheet()->getPageSetup()->setScale(50);
-        $writer = new \PHPExcel_Writer_PDF($this->objPHPExcel);
-        $writer->setPreCalculateFormulas(false);
-        //$writer->setSheetIndex(0);
-        //$writer->setPaperSize("A4");
-        $writer->writeAllSheets();
-
-        return $writer;
-    }
 }

--- a/Resources/doc/export/library-dependent_exports/PHPExcel/PHPExcel_PDF_export.md
+++ b/Resources/doc/export/library-dependent_exports/PHPExcel/PHPExcel_PDF_export.md
@@ -10,11 +10,11 @@ Mime type = `application/pdf`
 ```php
 <?php
 ...
-use APY\DataGridBundle\Grid\Export\PHPExcelPDFExport;
+use APY\DataGridBundle\Grid\Export\PHPExcelMPDFExport;
 ...
 $grid->setSource($source);
 
-$grid->addExport(new PHPExcelPDFExport($title, $fileName, $params, $charset, $role));
+$grid->addExport(new PHPExcelMPDFExport($title, $fileName, $params, $charset, $role));
 ...
 ```
 

--- a/composer.json
+++ b/composer.json
@@ -47,14 +47,15 @@
         "doctrine/mongodb-odm": "^2.2",
         "rector/rector": "^0.12.13",
         "dg/bypass-finals": "^1.3",
-        "symfony/security-bundle": "^3.0 || ^4.0 || ^5.0",
         "symfony/twig-bundle": "^3.0 || ^4.0 || ^5.0",
-        "doctrine/doctrine-bundle": "^2.5"
+        "doctrine/doctrine-bundle": "^2.5",
+        "phpoffice/phpspreadsheet": "^1.22",
+        "mpdf/mpdf": "^8.0"
     },
     "suggest": {
         "ext-intl": "Translate the grid",
         "ext-mbstring": "Convert your data with the right charset",
-        "PHPExcel": "Export the grid (Excel, HTML or PDF)",
+        "phpoffice/phpspreadsheet": "Export the grid (Excel, HTML or PDF)",
         "doctrine/orm": "If you want to use Entity as source, please require doctrine/orm",
         "doctrine/mongodb-odm": "If you want to use Document as source, please require doctrine/mongodb-odm",
         "jms/translation-bundle": "If you want to use translations"


### PR DESCRIPTION
Closes #1066

I kept the old Export files too, if they are really needed

the only change, PHPExcelPDFExport is now abstract because there might be more PDF Writer (currently MPDF)
but there is a writer for tcpdf too