### PR TITLE
fix : deprecated: htmlentities(): Passing null to parameter #1 ($string) of type string is deprecated

### DIFF
--- a/Grid/Source/Source.php
+++ b/Grid/Source/Source.php
@@ -576,6 +576,9 @@ abstract class Source implements DriverInterface
 
     private function removeAccents($str)
     {
+        if (!is_string($str)) {
+            return $str; // Retourne l'entrée telle quelle si ce n'est pas une chaîne
+        }        
         $entStr = htmlentities($str, ENT_NOQUOTES, 'UTF-8');
         $noaccentStr = preg_replace('#&([A-za-z])(?:acute|cedil|circ|grave|orn|ring|slash|th|tilde|uml);#', '\1', $entStr);
 


### PR DESCRIPTION
fix : Deprecated: htmlentities(): Passing null to parameter #1 ($string) of type string is deprecated