### PR TITLE
Fix symfony xml encoder not working since symfony 5.0

### DIFF
--- a/Grid/Export/XMLExport.php
+++ b/Grid/Export/XMLExport.php
@@ -28,15 +28,19 @@ class XMLExport extends Export
 
     public function computeData(Grid $grid)
     {
-        $xmlEncoder = new XmlEncoder();
-        $xmlEncoder->setRootNodeName('grid');
-        $serializer = new Serializer([new GetSetMethodNormalizer()], ['xml' => $xmlEncoder]);
+        if (defined(XmlEncoder::class.'::ROOT_NODE_NAME')) {
+            $xmlEncoder = new XmlEncoder([XmlEncoder::ROOT_NODE_NAME => 'grid']);
+        } else {
+            $xmlEncoder = new XmlEncoder();
+            $xmlEncoder->setRootNodeName('grid');
+        }
+        $serializer = new Serializer([new GetSetMethodNormalizer()], [XmlEncoder::FORMAT => $xmlEncoder]);
 
         $data = $this->getGridData($grid);
 
         $convertData['titles'] = $data['titles'];
         $convertData['rows']['row'] = $data['rows'];
 
-        $this->content = $serializer->serialize($convertData, 'xml');
+        $this->content = $serializer->serialize($convertData, XmlEncoder::FORMAT);
     }
 }


### PR DESCRIPTION
The method `setRootNodeName` is not available anymore since symfony 5.0. Instead the default context should be used.
This PR fixes this issue