### PR TITLE
Support symfony/security-core 7.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "symfony/http-foundation": "^3.0 || ^4.0 || ^5.0 || ^6.0",
         "symfony/http-kernel": "^3.0 || ^4.0 || ^5.0 || ^6.0",
         "symfony/options-resolver": "^3.0 || ^4.0 || ^5.0 || ^6.0",
-        "symfony/security-bundle": "^3.0 || ^4.0 || ^5.0 || ^6.0",
+        "symfony/security-core": "^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0",
         "symfony/serializer": "^3.0 || ^4.0 || ^5.0 || ^6.0",
         "twig/twig": "^2.14 || ^3.0"
     },
@@ -47,7 +47,7 @@
         "doctrine/mongodb-odm": "^2.2",
         "rector/rector": "^0.12.13",
         "dg/bypass-finals": "^1.3",
-        "symfony/security-bundle": "^3.0 || ^4.0 || ^5.0",
+        "symfony/security-bundle": "^3.0 || ^4.0 || ^5.0 || ^6.0 || ^7.0",
         "symfony/twig-bundle": "^3.0 || ^4.0 || ^5.0",
         "doctrine/doctrine-bundle": "^2.5"
     },


### PR DESCRIPTION
The composer requirement for package was changed to `symfony/security-core` as only classes from this component are required in the project.