### PR TITLE
fix: symfony xml encoder (#1117)

### DIFF
--- a/Grid/Export/XMLExport.php
+++ b/Grid/Export/XMLExport.php
@@ -28,15 +28,19 @@ class XMLExport extends Export
 
     public function computeData(Grid $grid)
     {
-        $xmlEncoder = new XmlEncoder();
-        $xmlEncoder->setRootNodeName('grid');
-        $serializer = new Serializer([new GetSetMethodNormalizer()], ['xml' => $xmlEncoder]);
+        if (defined(XmlEncoder::class.'::ROOT_NODE_NAME')) {
+            $xmlEncoder = new XmlEncoder([XmlEncoder::ROOT_NODE_NAME => 'grid']);
+        } else {
+            $xmlEncoder = new XmlEncoder();
+            $xmlEncoder->setRootNodeName('grid');
+        }
+        $serializer = new Serializer([new GetSetMethodNormalizer()], [XmlEncoder::FORMAT => $xmlEncoder]);
 
         $data = $this->getGridData($grid);
 
         $convertData['titles'] = $data['titles'];
         $convertData['rows']['row'] = $data['rows'];
 
-        $this->content = $serializer->serialize($convertData, 'xml');
+        $this->content = $serializer->serialize($convertData, XmlEncoder::FORMAT);
     }
 }


### PR DESCRIPTION
I have tested it locally with php 7 and 8, and lowest / latest dependencies.

Tests are passing, so I assume this is OK.

Thanks @deguif 